### PR TITLE
feature: intruducing the espFoC Tuner Studio! 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ examples/unit_test_runner/__pycache__/
 **/esp_foc_autotuned_report.txt
 scripts/motors/*.generated.json
 scripts/__pycache__/
+**/__pycache__/
 .cursor/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ if(ESP_PLATFORM)
 idf_build_get_property(target IDF_TARGET)
 
 set(requires esp_driver_uart esp_driver_pcnt esp_driver_gpio esp_driver_mcpwm esp_driver_ledc esp_adc driver freertos esp_system esp_timer)
+# esp_tinyusb is fetched conditionally for USB-capable targets via
+# idf_component.yml; declare the priv require eagerly here so the bridge
+# source file finds tinyusb.h on those targets even when the user has not
+# enabled CONFIG_ESP_FOC_BRIDGE_USBCDC at component-graph resolution time.
+if(target STREQUAL "esp32s2" OR target STREQUAL "esp32s3" OR target STREQUAL "esp32p4")
+    list(APPEND requires espressif__esp_tinyusb)
+endif()
 list(APPEND includes "source/drivers")
 list(APPEND srcs    "source/drivers/inverter_3pwm_ledc.c"
                     "source/drivers/inverter_3pwm_mcpwm.c"
@@ -33,6 +40,12 @@ list(APPEND srcs    "source/drivers/inverter_3pwm_ledc.c"
 
 if(CONFIG_ESP_FOC_TUNER_ENABLE)
     list(APPEND srcs "source/motor_control/esp_foc_tuner.c")
+endif()
+if(CONFIG_ESP_FOC_BRIDGE_UART)
+    list(APPEND srcs "source/drivers/esp_foc_bridge_uart.c")
+endif()
+if(CONFIG_ESP_FOC_BRIDGE_USBCDC)
+    list(APPEND srcs "source/drivers/esp_foc_bridge_usbcdc.c")
 endif()
 
 idf_component_register(SRCS "${srcs}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(srcs    "source/motor_control/esp_foc_core.c"
             "source/motor_control/control_strategy/esp_foc_control_current_mode_sensored.c"
             "source/motor_control/esp_foc_design_mpz.c"
+            "source/motor_control/esp_foc_link.c"
             "source/motor_control/esp_foc_axis_tuning.c"
             "source/motor_control/esp_foc_injection.c"
             "source/motor_control/esp_foc_scope.c"

--- a/Kconfig
+++ b/Kconfig
@@ -72,6 +72,50 @@ menu "espFoC Settings"
             esp_foc_tuner_attach_axis() and calls
             esp_foc_tuner_handle_request() from a transport task.
 
+    choice ESP_FOC_TUNER_BRIDGE
+        prompt "Tuner transport bridge"
+        depends on ESP_FOC_TUNER_ENABLE
+        default ESP_FOC_BRIDGE_NONE
+        help
+            Selects the physical bus that ferries tuner / scope frames
+            between the firmware and TunerStudio. Pick "None" if you
+            implement the weak callbacks in your own application.
+
+        config ESP_FOC_BRIDGE_NONE
+            bool "None (user provides callbacks)"
+
+        config ESP_FOC_BRIDGE_UART
+            bool "UART"
+            help
+                Uses one of the chip's UART peripherals; works on every
+                ESP32 variant including the original ESP32 without USB.
+
+        config ESP_FOC_BRIDGE_USBCDC
+            bool "USB CDC-ACM (TinyUSB)"
+            depends on IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32P4
+            help
+                Uses TinyUSB CDC-ACM. No external adapter required;
+                the same cable used to flash the board carries the tuner
+                traffic. Requires the espressif/tinyusb managed component.
+
+    endchoice
+
+    if ESP_FOC_BRIDGE_UART
+        config ESP_FOC_BRIDGE_UART_NUM
+            int "UART peripheral number"
+            range 0 2
+            default 1
+        config ESP_FOC_BRIDGE_UART_BAUD
+            int "UART baud rate"
+            default 921600
+        config ESP_FOC_BRIDGE_UART_TX_PIN
+            int "UART TX pin"
+            default 17
+        config ESP_FOC_BRIDGE_UART_RX_PIN
+            int "UART RX pin"
+            default 18
+    endif
+
     config ESP_FOC_INJECTION_ENABLE
         bool "Enable signal injection on the q-axis current reference"
         default n

--- a/README.md
+++ b/README.md
@@ -344,6 +344,23 @@ $ python3 scripts/verify_goldens.py
 All 5 goldens agree across JSON, Python math, and C mirror.
 ```
 
+### 5. TunerStudio (host GUI + CLI)
+
+`tools/espfoc_studio/` hosts the PySide6 + pyqtgraph desktop app and the
+`tunerctl` CLI that drive the firmware through the runtime tuner. The
+whole stack (link codec, protocol client, motor model, GUI) is pure
+Python and can be exercised against a simulated firmware with no hardware
+attached:
+
+```
+pip install -r tools/espfoc_studio/requirements.txt
+PYTHONPATH=tools python3 -m espfoc_studio.gui --demo
+```
+
+Swap `--demo` for `--port /dev/ttyACM0` once you flash a board built with
+`CONFIG_ESP_FOC_BRIDGE_UART` or `CONFIG_ESP_FOC_BRIDGE_USBCDC`. See
+`tools/espfoc_studio/README.md` for the full layout.
+
 ---
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -1,68 +1,40 @@
 # espFoC
-### Field Oriented Control (FOC) library for PMSM / BLDC motors on ESP32
+
+Field Oriented Control (FOC) library for PMSM / BLDC motors on the
+ESP32 family, built on ESP-IDF.
 
 ![Build](https://github.com/uLipe/espFoC/workflows/Build/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-![alt text](doc/images/espfoc_demo.gif)
+![espFoC running on hardware](doc/images/espfoc_demo.gif)
 
-espFoC is a **modular, real-time Field Oriented Control (FOC) library** for **PMSM and BLDC motors** on the **ESP32 family** using **ESP-IDF**. It provides motor driving and the full FOC signal chain: inverter control, current sensing, rotor feedback (sensor or observer), and torque (Id/Iq) regulation. Velocity and position loops are not included; you implement them in the regulation callback using the axis state (e.g. `axis->current_speed`, `axis->rotor_position`).
+espFoC covers the inner control chain: inverter drive, current
+sensing, rotor feedback and the Id/Iq torque loop. Velocity and
+position loops live in the application's regulation callback; the
+library stays focused and the hot path runs without floating-point
+math. Gains can be synthesised at build time, retuned live from the
+firmware API, or dialled in interactively through the bundled
+TunerStudio GUI.
 
-The project focuses on:
-- deterministic timing
-- clear separation between control logic and hardware drivers
-- extensibility (inverters, sensors, control strategies)
-- real hardware usage (not simulation)
-
----
-
-## Key Features
-
-- Voltage-mode FOC (open-loop and sensored)
-- Current-mode FOC (Id/Iq) with ADC shunt sensing and rotor sensor (sensored) or observer (sensorless, experimental)
-- Modular driver set:
-  - Inverters (3-PWM, 6-PWM MCPWM)
-  - Rotor sensors (encoders, observers; optional for open-loop)
-  - Current sensors (ADC shunt)
-- Hardware-synchronized PWM loop and MCPWM dead-time insertion
-- **ESP-IDF v5+**
+Targets: ESP32, ESP32-S3, ESP32-P4 (ESP-IDF v5+).
 
 ---
 
-## Quick Start
+## Install
 
-### 1. Install via ESP-IDF (recommended)
+Via the IDF component registry:
 
 ```bash
 idf.py add-dependency "ulipe/espfoc^2.0.0"
 ```
 
-Then:
-
-```bash
-idf.py set-target esp32        # or esp32s3 / esp32p4
-idf.py menuconfig
-idf.py build flash monitor
-```
-
----
-
-## Manual Component Integration
-
-Alternatively, clone this repository and add it to your project:
+Or clone the repo and add it to your project:
 
 ```cmake
 set(EXTRA_COMPONENT_DIRS "path/to/espFoC")
 ```
 
-Build an example:
-
-```bash
-cd examples/axis_sensored
-idf.py build flash monitor
-```
-
-Sensored quick start:
+Then pick an example as a starting point:
 
 ```bash
 cd examples/axis_sensored
@@ -72,433 +44,179 @@ idf.py build flash monitor
 
 ---
 
-## Architectural Overview
-
-espFoC is built around a **motor axis abstraction**. Each axis owns one
-inverter, one rotor sensor, and (optionally) one current sensor. The
-application provides a regulation callback that sets Id/Iq references;
-espFoC handles everything from the PID current loop down to PWM duty
-generation. Velocity and position loops are left to the application.
+## Architecture
 
 ![espFoC architecture](doc/images/architecture.png)
 
-This design allows mixing and matching hardware blocks without changing the control core. espFoC is limited to motor driving and the torque (current) loop; velocity and position control are left to the application via the regulation callback.
+Each axis owns one inverter, one rotor sensor and (optionally) one
+current sensor. The application sets Id/Iq references in a
+regulation callback; espFoC handles Clarke/Park transforms, the PI
+current loop, SVPWM modulation and the PWM duty outputs. Control
+timing is driven by the PWM peripheral — the ADC samples are
+PWM-synchronised and the Id/Iq loop runs in a deterministic task.
+
+Inverter and rotor drivers are pluggable:
+
+- Inverters: 3-PWM LEDC, 3-PWM MCPWM, 6-PWM MCPWM (hardware dead-time).
+- Rotor sensors: AS5600, AS5048, quadrature via PCNT, open-loop.
+- Current sensing: ADC shunt (continuous or one-shot).
 
 ---
 
-## Control Modes
+## Tuning
 
-### Voltage Mode
-- Direct control of Ud/Uq
-- Supports open-loop and sensored operation
-- Typical use: motor bring-up, observer tuning, simple drives
+![TunerStudio demo](doc/images/tuner_studio.png)
 
-### Current Mode
-- Closed-loop Id/Iq control
-- Requires a current sensor; sensored mode also requires a rotor sensor (encoder or equivalent)
-- Enables torque control (e.g. thrust or effort in EVs, drones, tools)
+espFoC ships with **TunerStudio**, a PySide6 + pyqtgraph desktop app
+that speaks the runtime tuner protocol over UART or USB-CDC. In a
+single window you get:
 
----
+- live axis state and gain readout with in-place editing;
+- MPZ recompute from motor R/L/bandwidth on the fly;
+- predicted step response, Bode, pole-zero and root-locus plots;
+- firmware scope stream with per-channel colour, toggle and cursor;
+- SVPWM hexagon with the three phase projections and the resultant
+  voltage vector rotating as the motor is driven.
 
-## Inverter Drivers
-
-### 3-PWM Inverters
-- LEDC based
-- MCPWM based
-- Single output per phase
-- Suitable for integrated power stages
-
-### 6-PWM MCPWM Inverter
-- Complementary outputs per phase (high-side / low-side)
-- Hardware dead-time insertion
-- Suitable for:
-  - discrete MOSFET bridges
-  - external gate drivers
-
-Dead-time is handled **in hardware** using the MCPWM peripheral and is
-configured conservatively by default.
-
-> Dead-time configuration assumes complementary outputs and appropriate
-> external power stage protection.
-
----
-
-## Rotor Sensors
-
-Supported rotor sensing methods include:
-- Open-loop (no sensor)
-- Incremental encoders
-- Magnetic encoders (e.g. AS5600)
-- Observer-based estimation
-
-Rotor sensors are implemented as pluggable drivers and can be replaced
-without modifying the control logic.
-
----
-
-## Current Sensing
-
-espFoC supports **ADC shunt current sensing**:
-- dual or three-shunt configurations
-- Synchronized with PWM events
-- Used for:
-  - current-mode FOC
-  - observer feedback
-
----
-
-## Real-Time Design
-
-espFoC is designed around **hardware-driven timing**:
-
-- PWM timer drives the control loop
-- ADC sampling is synchronized to PWM
-- High-speed ISR captures timestamps and samples
-- Control computation runs in a deterministic high priority task
-
----
-
-## PI Tuning Workflow
-
-espFoC ships with three complementary mechanisms for the current-loop PI:
-build-time autotuning, runtime retune, and a transport-agnostic tuner
-backend with optional signal injection. All three share the same
-**Matched Pole-Zero (MPZ) discrete-time synthesis** so the gains are
-consistent across boot, host tooling, and live retuning.
-
-The closed-form design assumes the standard first-order PMSM current
-plant `G(s) = 1 / (R + L·s)` with ZOH discretization at the loop sample
-period `Ts = decimation / f_pwm`:
-
-```
-alpha = exp(-R*Ts/L)              # discrete plant pole
-beta  = exp(-2*pi*bw_hz*Ts)       # desired closed-loop pole
-Kp    = R*(1 - beta)/(1 - alpha)
-Ki    = R*(1 - beta)/Ts
-```
-
-### 1. Build-time autotuner
-
-Motor profiles live under `scripts/motors/*.json`. Select one with
-`CONFIG_ESP_FOC_MOTOR_PROFILE` and the build runs `scripts/gen_pi_gains.py`,
-emitting `esp_foc_autotuned_gains.h` into the **build directory** (never the
-source tree, defended both by `.gitignore` rules and by the script's
-`--allow-in-tree` guard). The gains are picked up at boot whenever
-`esp_foc_motor_control_settings_t.motor_resistance` and `motor_inductance`
-are zero.
-
-Sample build-time output:
-
-```
-$ python3 scripts/gen_pi_gains.py \
-      --motor scripts/motors/default.json \
-      --output build/.../gen/esp_foc_autotuned_gains.h \
-      --report build/.../gen/esp_foc_autotuned_report.txt \
-      --pwm-rate-hz 20000 --decimation 20
-WARNING: phase margin (with 1-sample delay) is only 36.7 deg.
-espFoC PI autotuner: build/.../esp_foc_autotuned_gains.h generated
-                     (Kp=1.4610 V/A, Ki=659.17 V/(A*s), PM_delay=36.7 deg)
-```
-
-The report sidecar captures the full design context:
-
-```
-espFoC PI autotuning report
-===========================
-Profile     : iPower GBM5208-200T (gimbal reference) (default.json)
-Motor       : R = 1.080000 ohm, L = 1800.000 uH
-Loop        : PWM = 20000 Hz, decimation = 20, Ts = 1000 us
-Target BW   : 150.000 Hz (bw*Ts = 0.1500)
-V max       : 12.000 V
-
-Discrete plant pole alpha = exp(-R*Ts/L) = 0.548812
-Closed-loop pole    beta  = exp(-w_bw*Ts) = 0.389661
-
-Kp                 = 1.460955 V/A
-Ki                 = 659.166 V/(A*s)
-Integrator limit   = 12.000 V
-
-Phase margin (no delay)        : 72.2 deg
-Phase margin (1-sample delay)  : 36.7 deg
-```
-
-The script aborts the build when the design is unsafe. Two examples:
-
-```
-# bw above Nyquist: bw_hz * Ts >= 0.5
-ERROR: design failed: bandwidth 1000.0 Hz exceeds Nyquist for Ts=1000.0us
-       (bw*Ts=1.000 >= 0.5)
-exit=4
-
-# phase margin (with 1-sample delay) below the profile's safety floor
-ERROR: phase margin (with 1-sample delay) 27.1 deg < required 60.0 deg.
-       Reduce target bandwidth or revisit the motor profile.
-exit=5
-```
-
-### 2. Runtime retune API
-
-`include/espFoC/esp_foc_axis_tuning.h` exposes three primitives:
-
-```c
-esp_foc_axis_retune_current_pi_q16(axis, R_q16, L_q16, bw_hz_q16);
-esp_foc_axis_set_current_pi_gains_q16(axis, Kp, Ki, integrator_limit);
-esp_foc_axis_get_current_pi_gains_q16(axis, &Kp, &Ki, &lim);
-```
-
-`retune` invokes the same MPZ math the Python generator uses (now in
-fixed-point Q16, `source/motor_control/esp_foc_design_mpz.c`) and swaps
-the gains atomically through a critical section. The integrator and
-previous-error history are reset to keep the post-swap response
-well-defined.
-
-### 3. Tuner backend & signal injection
-
-Behind `CONFIG_ESP_FOC_TUNER_ENABLE`, `esp_foc_tuner.c` exposes a
-transport-agnostic request handler that maps to read / write / exec
-opcodes (`include/espFoC/esp_foc_tuner.h`). Three weak callbacks
-(`esp_foc_tuner_init_bus_callback`, `_recv_callback`, `_send_callback`)
-let the application plug UART, USB-CDC, BLE or TCP without touching
-the core.
-
-With `CONFIG_ESP_FOC_INJECTION_ENABLE` the q-axis reference can be
-augmented with a step or chirp from `esp_foc_axis_inject_step_q16()` /
-`esp_foc_axis_inject_chirp_q16()`, which closes the loop with the
-existing scope: arm injection, capture, plot, repeat.
-
-### 4. End-to-end demo (runs in QEMU)
-
-`examples/tuner_demo` is a self-contained app that exercises every
-piece above. From the example directory:
+### Try it without hardware
 
 ```bash
-. $IDF_PATH/export.sh
-idf.py set-target esp32
-idf.py build
-python run_qemu.py
-```
-
-Output captured from QEMU:
-
-```
-I (..) tuner-demo: espFoC tuner demo starting (PWM=20000 Hz, decimation=20)
-I (..) tuner-demo: === Initial gains (build-time autogen, default.json) ===
-I (..) tuner-demo: autogen default        Kp=   1.4610 V/A   Ki=   659.17 V/(A*s)   ILim= 12.00 V
-I (..) tuner-demo: === Runtime retune via MPZ helper ===
-I (..) tuner-demo: retune iPower (R=1.08,L=1.8mH): R=1.080 L=1.8000mH bw=150Hz
-I (..) tuner-demo: iPower (R=1.08,L=1.8mH) Kp=   1.4613 V/A   Ki=   659.15 V/(A*s)   ILim=  0.58 V
-I (..) tuner-demo: retune low-R servo  (R=0.25,L=0.8mH): R=0.250 L=0.8000mH bw=200Hz
-I (..) tuner-demo: low-R servo  (R=0.25,L=0.8mH) Kp=   0.6618 V/A   Ki=   178.85 V/(A*s)   ILim=  0.58 V
-I (..) tuner-demo: retune high-L motor (R=0.80,L=5.0mH): R=0.800 L=5.0000mH bw=50Hz
-I (..) tuner-demo: high-L motor (R=0.80,L=5.0mH) Kp=   1.4600 V/A   Ki=   215.67 V/(A*s)   ILim=  0.58 V
-I (..) tuner-demo: Asking for a bandwidth above Nyquist (bw=600Hz, Ts=1ms):
-I (..) tuner-demo: retune above-nyquist demo: R=0.500 L=1.0000mH bw=600Hz
-W (..) tuner-demo: retune REJECTED (err=-2) -- bw probably above Nyquist for the current loop period
-I (..) tuner-demo: === Tuner protocol round-trip ===
-I (..) tuner-demo: READ Kp -> 1.4600 V/A
-I (..) tuner-demo: WRITE Kp = 2.345 (manual override)
-I (..) tuner-demo: READ Kp -> 2.3450 V/A (after write)
-I (..) tuner-demo: EXEC RECOMPUTE_GAINS R=1.08 L=1.8mH bw=150Hz
-I (..) tuner-demo: READ Kp -> 1.4613 V/A (after MPZ recompute)
-I (..) tuner-demo: READ Ki -> 659.15 V/(A*s)
-I (..) tuner-demo: === Signal injection (step) ===
-I (..) tuner-demo: arm_step amplitude=0.5A duration=5ms -> OK
-I (..) tuner-demo: step sample[0] = 0.500 A
-I (..) tuner-demo: step sample[1] = 0.500 A
-I (..) tuner-demo: step sample[2] = 0.500 A
-I (..) tuner-demo: step sample[3] = 0.500 A
-I (..) tuner-demo: step sample[4] = 0.000 A
-I (..) tuner-demo: === Signal injection (chirp 100->500 Hz) ===
-I (..) tuner-demo: arm_chirp amplitude=0.25A 100->500Hz over 10ms -> OK
-I (..) tuner-demo: chirp observed peak = 0.250 A (expected ~0.25)
-I (..) tuner-demo: === Demo complete ===
-```
-
-A few sanity checks on those numbers:
-
-- **autogen default vs iPower retune** produce the same Kp/Ki because
-  `default.json` *is* the iPower gimbal motor — the runtime path matches
-  the build-time path within Q16 quantization (1 LSB).
-- **low-R / high-L** motors yield clearly different Kp values, showing the
-  MPZ design adapting to the plant.
-- The integrator limit drops from `12.00 V` (build-time, from JSON
-  `v_max_volts`) to `0.58 V` after runtime retune. That's expected: the
-  runtime path uses the **actual** `axis->max_voltage`, derived from the
-  inverter's reported DC link (here `1.0 V` with SVPWM →
-  `1/√3 ≈ 0.577 V`).
-- The above-Nyquist request is rejected cleanly (`err=-2`) instead of
-  silently corrupting the gains.
-- Step injection delivers exactly five samples at 0.5 A then auto-disables
-  (5 ms @ 1 ms loop period, less the Q16 quantization of `Ts`).
-- Chirp peak matches the configured amplitude (0.25 A).
-
-### Cross-validation Python ↔ C
-
-`test/golden_motors.json` is the single source of truth for the regression
-table. `scripts/verify_goldens.py` checks both that the Python math agrees
-with the JSON and that the C test mirror in `test/test_design_mpz.c`
-matches it byte-for-byte:
-
-```
-$ python3 scripts/verify_goldens.py
-All 5 goldens agree across JSON, Python math, and C mirror.
-```
-
-### 5. TunerStudio (host GUI + CLI)
-
-`tools/espfoc_studio/` hosts the PySide6 + pyqtgraph desktop app and the
-`tunerctl` CLI that drive the firmware through the runtime tuner. The
-whole stack (link codec, protocol client, motor model, GUI) is pure
-Python and can be exercised against a simulated firmware with no hardware
-attached:
-
-```
 pip install -r tools/espfoc_studio/requirements.txt
 PYTHONPATH=tools python3 -m espfoc_studio.gui --demo
 ```
 
-Swap `--demo` for `--port /dev/ttyACM0` once you flash a board built with
-`CONFIG_ESP_FOC_BRIDGE_UART` or `CONFIG_ESP_FOC_BRIDGE_USBCDC`. See
-`tools/espfoc_studio/README.md` for the full layout.
+`--demo` embeds a simulated firmware so the whole pipeline — tuner
+protocol, scope stream, hexagon — exercises end-to-end with zero
+boards attached.
+
+### Talk to a real target
+
+Enable a transport bridge in `menuconfig`:
+
+- `CONFIG_ESP_FOC_BRIDGE_UART` — works on every ESP32 variant.
+- `CONFIG_ESP_FOC_BRIDGE_USBCDC` — S2 / S3 / P4; same cable as flashing.
+
+Flash a firmware that has `CONFIG_ESP_FOC_TUNER_ENABLE=y`, then:
+
+```bash
+PYTHONPATH=tools python3 -m espfoc_studio.gui --port /dev/ttyACM0
+```
+
+### Scripted tuning
+
+A companion CLI (`tunerctl`) lets you drive the same protocol from
+scripts and CI jobs. Build-time autotuning from motor profiles, the
+runtime C API, the wire-level protocol and the CLI commands are
+covered in [`doc/TUNING.md`](doc/TUNING.md).
 
 ---
 
-## Examples
+## Minimal example
 
-The repository includes multiple examples demonstrating:
-- Sensored mode (`examples/axis_sensored`)
-- Sensorless mode (`examples/axis_sensorless`) — **temporarily disabled**:
-  the rotor observer is not yet wired into the axis. The example aborts at
-  compile time with a clear error unless `CONFIG_EXAMPLE_BUILD_INCOMPLETE_SENSORLESS`
-  is set, and even then app_main logs an error and returns without driving
-  the inverter.
-- Inverter and sensor bring-up (`examples/test_drivers`)
-- **tuner_demo** (`examples/tuner_demo`): self-contained app that exercises
-  build-time autogen, runtime retune, the tuner protocol, and signal
-  injection. Runs unchanged in QEMU via `python run_qemu.py`.
-- **unit_test_runner**: app that runs the Unity unit tests (for CI or local
-  validation). Build with `idf.py -D TEST_COMPONENTS=espFoC build` from
-  `examples/unit_test_runner`.
-
-Examples are located in the `examples/` directory.
-
----
-
-## Sample Code
-
-Below is a minimal example that initializes espFoC and runs the motor in **sensored current mode** with:
-
-- MCPWM inverter
-- rotor sensor (e.g. AS5600)
-- current sensor (ADC shunt)
+Sensored current mode with a 6-PWM MCPWM inverter, an AS5600 encoder
+and an ADC shunt. With `CONFIG_ESP_FOC_USE_AUTOGEN_GAINS=y` (default)
+the PI gains come from the selected motor profile; leave
+`motor_resistance` / `motor_inductance` zeroed to use that path, or
+fill them in to fall back on the legacy continuous-time formula.
 
 ```c
 #include "esp_log.h"
 #include "esp_err.h"
-
 #include "espFoC/inverter_6pwm_mcpwm.h"
 #include "espFoC/current_sensor_adc.h"
 #include "espFoC/rotor_sensor_as5600.h"
 #include "espFoC/esp_foc.h"
 #include "espFoC/utils/esp_foc_q16.h"
 
-static const char *TAG = "esp-foc-example";
-
-static esp_foc_inverter_t *inverter;
-static esp_foc_isensor_t  *shunts;
-static esp_foc_rotor_sensor_t *sensor;
-
 static esp_foc_axis_t axis;
 static esp_foc_motor_control_settings_t settings = {
-    .motor_pole_pairs = 4,
-    .motor_inductance = 0,
-    .motor_resistance = 0,
+    .motor_pole_pairs  = 4,
+    .motor_inductance  = 0,   /* zero => use autogen / TunerStudio */
+    .motor_resistance  = 0,
     .natural_direction = ESP_FOC_MOTOR_NATURAL_DIRECTION_CW,
-    .motor_unit = 0,
+    .motor_unit        = 0,
 };
 
 static void regulation_callback(esp_foc_axis_t *axis_cb,
                                 esp_foc_d_current_q16_t *id_ref,
                                 esp_foc_q_current_q16_t *iq_ref,
-                                esp_foc_d_voltage_q16_t *ud_forward,
-                                esp_foc_q_voltage_q16_t *uq_forward)
+                                esp_foc_d_voltage_q16_t *ud_ff,
+                                esp_foc_q_voltage_q16_t *uq_ff)
 {
     (void)axis_cb;
-    uq_forward->raw = q16_from_float(0.0f);
-    ud_forward->raw = q16_from_float(0.0f);
+    ud_ff->raw = 0;
+    uq_ff->raw = 0;
+    id_ref->raw = 0;
     iq_ref->raw = q16_from_float(2.0f);
-    id_ref->raw = q16_from_float(0.0f);
 }
 
 void app_main(void)
 {
-    ESP_LOGI(TAG, "Initializing espFoC");
+    esp_foc_inverter_t     *inv    = inverter_6pwm_mpcwm_new(/* pins... */);
+    esp_foc_rotor_sensor_t *rotor  = rotor_sensor_as5600_new(/* i2c... */);
+    esp_foc_isensor_t      *shunts = /* ... ADC shunt config ... */;
 
-    settings.motor_inductance = q16_from_float(0.0018f);
-    settings.motor_resistance = q16_from_float(1.08f);
-
-    inverter = inverter_6pwm_mpcwm_new(/* ... pin config ... */);
-    shunts   = /* ... ADC shunt config ... */;
-    sensor   = rotor_sensor_as5600_new(/* ... I2C pins ... */);
-
-    esp_foc_initialize_axis(&axis, inverter, sensor, shunts, settings);
+    esp_foc_initialize_axis(&axis, inv, rotor, shunts, settings);
     esp_foc_align_axis(&axis);
     esp_foc_run(&axis);
     esp_foc_set_regulation_callback(&axis, regulation_callback);
 }
 ```
 
-## Numerical Format
+---
 
-espFoC uses **Q16.16 fixed-point** (`q16_t`) for all runtime control signals
-(currents, voltages, angles, PID, filters, SVPWM). An IQ31 (Q1.31) LUT
-provides sin/cos and is also used inside observers. **Float** is used only in
-the public API for setup / parameter conversion (e.g. `q16_from_float()`);
-the hot-path control loop contains no floating-point operations.
+## Examples
+
+- `examples/axis_sensored` — reference bring-up (sensored current mode).
+- `examples/axis_sensorless` — placeholder; the observer integration
+  is being reworked. Compile is gated by
+  `CONFIG_EXAMPLE_BUILD_INCOMPLETE_SENSORLESS` so nobody ships a
+  broken binary by accident.
+- `examples/tuner_demo` — runs in QEMU, exercises autogen gains,
+  runtime retune, the tuner protocol and signal injection.
+- `examples/unit_test_runner` — Unity suite for CI / QEMU.
+- `examples/test_drivers` — inverter / encoder / shunt bring-up.
 
 ---
 
-## Repository Structure
+## Numerical format
 
-```
-  espFoC/
-  ├── doc
-  │   └── images
-  ├── examples   # Examples with examples projects and bring-up code
-  │   ├── axis_sensored
-  │   ├── axis_sensorless
-  │   └── test_drivers
-  ├── include   # Public API header files
-  │   └── espFoC
-  └── source
-      ├── drivers         # Platform specific drivers
-      ├── motor_control   # Motor control algorithms.
-      ├── osal            # OS abstraction layer
-      └── rust            # plain FFI for future rust usage
-
-```
+Q16.16 fixed-point (`q16_t`) is used everywhere in the hot path:
+currents, voltages, angles, PID, filters, SVPWM. A Q1.31 (IQ31) LUT
+backs sin/cos and the observers. Float is reserved for setup-time
+conversions via `q16_from_float()` / `q16_to_float()`; the control
+loop contains no floating-point operations.
 
 ---
 
-## Project Status
+## Repository layout
 
-espFoC is a personal project. The 2.x API focuses on motor driving and FOC only; velocity and position loops are not part of the library. Future releases may introduce breaking changes.
+```
+espFoC/
+├── doc/
+│   ├── images/         # architecture, TunerStudio screenshot, demo gif
+│   └── TUNING.md       # deep dive: autogen, runtime API, protocol, CLI
+├── examples/           # axis_sensored / axis_sensorless / tuner_demo / ...
+├── include/espFoC/     # public API
+├── scripts/
+│   ├── gen_pi_gains.py # build-time MPZ autotuner
+│   └── motors/*.json   # motor profiles consumed by the autotuner
+├── source/
+│   ├── drivers/        # platform drivers (inverters, encoders, shunts)
+│   ├── motor_control/  # axis core, MPZ design, tuner, injection, link codec
+│   └── osal/           # OS abstraction
+├── test/               # Unity unit tests (run via examples/unit_test_runner)
+└── tools/espfoc_studio # PySide6 + pyqtgraph GUI and CLI
+```
 
 ---
 
 ## License
 
-espFoC is released under the **MIT License**.
-
-See `LICENSE` for details.
-
----
+MIT — see `LICENSE`.
 
 ## Contributing
 
-Issues, feature requests, and pull requests are welcome.
+Issues, feature requests and pull requests are welcome.
 
-Maintainer: **Felipe Neves**
-`ryukokki.felipe@gmail.com`
-
----
+Maintainer: **Felipe Neves** — `ryukokki.felipe@gmail.com`

--- a/doc/TUNING.md
+++ b/doc/TUNING.md
@@ -1,0 +1,153 @@
+# espFoC tuning reference
+
+Complete reference for every way gains can be produced and updated in
+espFoC — complements the high-level tour in the main README. Order
+reflects the typical bring-up flow: pick a motor profile at build
+time, flash, then refine live through the TunerStudio GUI (or the
+`tunerctl` CLI for scripting).
+
+## Matched Pole-Zero synthesis
+
+The tuner, the build-time autogen and the host `model.analysis` module
+all share the same closed-form design, assuming a first-order PMSM
+current plant `G(s) = 1 / (R + L·s)` and ZOH discretization at the
+control-loop period `Ts = decimation / f_pwm`:
+
+```
+alpha = exp(-R·Ts/L)              # discrete plant pole
+beta  = exp(-2·pi·bw_hz·Ts)       # desired closed-loop pole
+Kp    = R·(1 − beta)/(1 − alpha)
+Ki    = R·(1 − beta)/Ts
+```
+
+## Build-time autotuner
+
+Motor profiles live in `scripts/motors/*.json`. Selecting one with
+`CONFIG_ESP_FOC_MOTOR_PROFILE` runs `scripts/gen_pi_gains.py` during
+the build and emits `esp_foc_autotuned_gains.h` into the **build
+directory** (never the source tree — `.gitignore` and a path guard in
+the script keep it that way).
+
+The generated header is consumed by `esp_foc_initialize_axis()`
+whenever both `motor_resistance` and `motor_inductance` are left at
+zero in the settings struct, so the application picks up the tuned
+values without touching runtime code.
+
+Example run on the reference gimbal profile:
+
+```
+$ python3 scripts/gen_pi_gains.py \
+      --motor scripts/motors/default.json \
+      --output build/.../gen/esp_foc_autotuned_gains.h \
+      --report build/.../gen/esp_foc_autotuned_report.txt \
+      --pwm-rate-hz 20000 --decimation 20
+espFoC PI autotuner: ...esp_foc_autotuned_gains.h generated
+                     (Kp=1.4610 V/A, Ki=659.17 V/(A*s), PM_delay=36.7 deg)
+```
+
+The script aborts the build when the result would be unsafe:
+
+- `exit 4` — requested bandwidth above Nyquist (`bw·Ts ≥ 0.5`);
+- `exit 5` — phase margin below the profile's `min_phase_margin_deg`.
+
+A human-readable report sidecar (`...autotuned_report.txt`) records
+the design context (motor params, Ts, α/β, Kp/Ki, phase-margin
+estimates) for the CI log.
+
+## Runtime tuning API
+
+`include/espFoC/esp_foc_axis_tuning.h` exposes three primitives that
+apply atomically through a short critical section; the integrator is
+reset on every swap to keep the post-swap response well-defined:
+
+```c
+esp_foc_axis_retune_current_pi_q16(axis, R_q16, L_q16, bw_hz_q16);
+esp_foc_axis_set_current_pi_gains_q16(axis, Kp, Ki, integrator_limit);
+esp_foc_axis_get_current_pi_gains_q16(axis, &Kp, &Ki, &lim);
+```
+
+`retune` uses the same MPZ math as `gen_pi_gains.py`, implemented in
+`source/motor_control/esp_foc_design_mpz.c` with pure Q16 arithmetic.
+
+## Tuner protocol
+
+With `CONFIG_ESP_FOC_TUNER_ENABLE` the firmware links a
+transport-agnostic request handler (`esp_foc_tuner.c`) that speaks a
+compact binary protocol on top of a framing codec
+(`esp_foc_link.c` — sync byte, LE length, channel, seq, payload,
+CRC-16/CCITT). Three channels are multiplexed over one bus:
+
+- `TUNER` — request/response.
+- `SCOPE` — CSV text from `esp_foc_scope.c` (one line per sample).
+- `LOG` — reserved for future log relay.
+
+Supported operations, mapped to `esp_foc_tuner_id_t`:
+
+| Op    | Category         | IDs (hex)                                      |
+|-------|------------------|------------------------------------------------|
+| READ  | gains + state    | `0x10..0x13` (Kp, Ki, ILim, Vmax), `0x40..0x41` (state, last err) |
+| WRITE | manual gains     | `0x20..0x22`                                   |
+| WRITE | motion targets   | `0x50..0x53` (id, iq, ud, uq — only honored while override is ON) |
+| EXEC  | commands         | `0x80` RECOMPUTE_GAINS, `0xA0` OVERRIDE_ON, `0xA1` OVERRIDE_OFF    |
+
+Axis validation: every call checks an `axis->magic` field (present
+only when the tuner is compiled in) so a stale or wild pointer is
+refused immediately.
+
+Override semantics: while `OVERRIDE_ON` is active the outer loop
+still invokes the user's regulation callback but drops its writes on
+the floor, honouring only the tuner shadow targets. `OVERRIDE_OFF`
+restores user control bumplessly — no transient glitch at the swap.
+
+## Transport bridges
+
+Two bridges live under `source/drivers/`; pick one in menuconfig.
+Both implement the weak callbacks declared in `esp_foc_tuner.h` and
+`esp_foc_scope.c`, so tuner and scope share a single physical bus.
+
+- `CONFIG_ESP_FOC_BRIDGE_UART` — works on every ESP32 variant
+  (including the original ESP32 without native USB). Peripheral,
+  baud and pin map are Kconfig entries.
+- `CONFIG_ESP_FOC_BRIDGE_USBCDC` — S2/S3/P4 only. Uses the
+  `espressif/esp_tinyusb` managed component; the same cable used
+  for flashing carries the tuner traffic.
+
+## tunerctl CLI
+
+`tools/espfoc_studio/cli/tunerctl.py` is a thin argparse wrapper
+around the Python `TunerClient` — handy when scripting bring-up
+sequences or wiring the tuner into CI:
+
+```bash
+# axis state
+python3 -m espfoc_studio.cli.tunerctl --port /dev/ttyACM0 axis-state
+
+# read current gains
+python3 -m espfoc_studio.cli.tunerctl --port /dev/ttyACM0 read
+
+# recompute gains from motor params
+python3 -m espfoc_studio.cli.tunerctl --port /dev/ttyACM0 \
+      retune --r 1.08 --l 0.0018 --bw 150
+
+# engage tuner-controlled motion
+python3 -m espfoc_studio.cli.tunerctl --port /dev/ttyACM0 override on
+python3 -m espfoc_studio.cli.tunerctl --port /dev/ttyACM0 set-target iq 1.5
+python3 -m espfoc_studio.cli.tunerctl --port /dev/ttyACM0 override off
+```
+
+Set `PYTHONPATH=tools` if you have not installed the package.
+
+## Cross-validation Python ↔ C
+
+`test/golden_motors.json` is the single source of truth for the
+regression table. `scripts/verify_goldens.py` checks both that the
+Python math agrees with the JSON and that the C mirror in
+`test/test_design_mpz.c` matches byte-for-byte:
+
+```
+$ python3 scripts/verify_goldens.py
+All 5 goldens agree across JSON, Python math, and C mirror.
+```
+
+Any drift in either side breaks the check immediately so the two
+implementations cannot diverge silently.

--- a/examples/unit_test_runner/run_unit_tests_qemu.py
+++ b/examples/unit_test_runner/run_unit_tests_qemu.py
@@ -21,21 +21,33 @@ def main() -> int:
     script_dir = os.path.dirname(os.path.abspath(__file__))
     os.chdir(script_dir)
     # Run idf.py qemu; it will build first if needed
-    child = pexpect.spawn("idf.py qemu", timeout=150, encoding="utf-8", codec_errors="replace", cwd=script_dir)
+    child = pexpect.spawn("idf.py qemu", timeout=300, encoding="utf-8",
+                          codec_errors="replace", cwd=script_dir)
     child.logfile = sys.stdout
 
     try:
-        child.expect("Press ENTER to see the list of tests.", timeout=60)
+        child.expect("Press ENTER to see the list of tests.", timeout=120)
     except (pexpect.TIMEOUT, pexpect.EOF) as e:
         print(f"Failed to get Unity menu: {e}")
         return 1
 
+    # Press Enter to print the menu, then wait for Unity's input prompt
+    # before sending "*". Doing them back-to-back is race-prone under CI
+    # I/O buffering and Unity silently discards the "*" if it arrives
+    # before the menu prompt is ready.
     child.sendline("")
+    try:
+        child.expect("Enter test for running", timeout=60)
+    except (pexpect.TIMEOUT, pexpect.EOF):
+        print("Unity menu prompt never appeared")
+        return 1
     child.sendline("*")
 
-    # Match "0 Failures" in the summary line (success)
+    # Match "0 Failures" in the summary line (success). QEMU runs
+    # tests serially; ~200 tests need comfortably more than two minutes
+    # on a loaded CI runner, so we budget five.
     try:
-        child.expect(re.compile(r"\d+ Tests 0 Failures"), timeout=120)
+        child.expect(re.compile(r"\d+ Tests 0 Failures"), timeout=300)
     except pexpect.TIMEOUT:
         print("Timeout waiting for test results or tests failed (non-zero failures).")
         return 1

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,11 @@
 dependencies:
   idf: '>=5.0'
+  espressif/esp_tinyusb:
+    # USB-CDC bridge (esp_foc_bridge_usbcdc.c) needs TinyUSB. Pulled in
+    # only on USB-capable targets so esp32 stays lightweight.
+    version: "^2.0.1~1"
+    rules:
+      - if: "idf_target in [esp32s2, esp32s3, esp32p4]"
 description: "Field Oriented Control (FOC) library for PMSM/BLDC motors on ESP32. Motor driving and torque loop; velocity/position loops are implemented by the application via regulation callback."
 version: "2.0.0"
 repository: "https://github.com/uLipe/espFoC.git"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,10 +2,14 @@ dependencies:
   idf: '>=5.0'
   espressif/esp_tinyusb:
     # USB-CDC bridge (esp_foc_bridge_usbcdc.c) needs TinyUSB. Pulled in
-    # only on USB-capable targets so esp32 stays lightweight.
+    # only on USB-capable targets so esp32 stays lightweight. The
+    # variable inside `if:` is `target` (NOT `idf_target`) per the
+    # idf-component-manager manifest reference; using the wrong name
+    # silently marks the dep as optional and skips the fetch, which
+    # then breaks the component graph in CI for s3/p4 builds.
     version: "^2.0.1~1"
     rules:
-      - if: "idf_target in [esp32s2, esp32s3, esp32p4]"
+      - if: "target in [esp32s2, esp32s3, esp32p4]"
 description: "Field Oriented Control (FOC) library for PMSM/BLDC motors on ESP32. Motor driving and torque loop; velocity/position loops are implemented by the application via regulation callback."
 version: "2.0.0"
 repository: "https://github.com/uLipe/espFoC.git"

--- a/include/espFoC/esp_foc_axis.h
+++ b/include/espFoC/esp_foc_axis.h
@@ -3,6 +3,8 @@
  */
 #pragma once
 
+#include <stdbool.h>
+#include <sdkconfig.h>
 #include "espFoC/esp_foc_units_q16.h"
 #include "espFoC/utils/pid_controller.h"
 #include "espFoC/utils/ema_low_pass_filter.h"
@@ -11,6 +13,11 @@
 #include "espFoC/drivers/current_sensor_interface.h"
 #include "espFoC/drivers/rotor_sensor_interface.h"
 #include "espFoC/osal/os_interface.h"
+
+/* Magic number used to validate axis pointers handed to the runtime tuner.
+ * Lives only when CONFIG_ESP_FOC_TUNER_ENABLE is set so nano builds pay
+ * zero overhead. Set in esp_foc_initialize_axis(). */
+#define ESP_FOC_AXIS_MAGIC ((uint32_t)0xF0CA1515)
 
 typedef struct esp_foc_axis_s esp_foc_axis_t;
 
@@ -33,7 +40,24 @@ typedef struct {
     int motor_unit;
 } esp_foc_motor_control_settings_t;
 
+#if defined(CONFIG_ESP_FOC_TUNER_ENABLE)
+typedef struct {
+    bool active;
+    q16_t target_id;
+    q16_t target_iq;
+    q16_t target_ud;
+    q16_t target_uq;
+} esp_foc_tuner_override_t;
+#endif
+
 struct esp_foc_axis_s {
+#if defined(CONFIG_ESP_FOC_TUNER_ENABLE)
+    /* Validates this struct came from esp_foc_initialize_axis() before any
+     * tuner-driven mutation. Defends against stale or wild axis pointers. */
+    uint32_t magic;
+    esp_foc_tuner_override_t tuner_override;
+#endif
+
     q16_t i_u;
     q16_t i_v;
     q16_t i_w;

--- a/include/espFoC/esp_foc_bridge_uart.h
+++ b/include/espFoC/esp_foc_bridge_uart.h
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+/**
+ * @file esp_foc_bridge_uart.h
+ * @brief UART bridge for the espFoC tuner / scope link.
+ *
+ * Implements the weak callbacks declared by esp_foc_tuner.h so any
+ * espFoC build can talk to the host TunerStudio over a regular UART:
+ *
+ *   - esp_foc_tuner_init_bus_callback()   -> driver install + RX task
+ *   - esp_foc_tuner_recv_callback()       -> shim around uart_read_bytes
+ *   - esp_foc_tuner_send_callback()       -> shim around uart_write_bytes
+ *
+ * Pin/baud configuration lives in Kconfig; the bridge spawns a single
+ * RX task that pumps incoming bytes into esp_foc_tuner_process_byte().
+ *
+ * Compiled into the espFoC component when CONFIG_ESP_FOC_BRIDGE_UART
+ * is set. Mutually exclusive with the USB-CDC bridge.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The bridge installs itself automatically the first time
+ * esp_foc_tuner_init_bus_callback() is invoked, so no public symbol is
+ * exported here beyond the weak overrides defined in the C file. This
+ * header exists so user code can include it explicitly to force the
+ * bridge to be linked in even when -fdata-sections is in play. */
+void esp_foc_bridge_uart_link_anchor(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/espFoC/esp_foc_bridge_usbcdc.h
+++ b/include/espFoC/esp_foc_bridge_usbcdc.h
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+/**
+ * @file esp_foc_bridge_usbcdc.h
+ * @brief TinyUSB CDC-ACM bridge for the espFoC tuner / scope link.
+ *
+ * Implements the weak callbacks declared by esp_foc_tuner.h on top of
+ * the espressif/esp_tinyusb managed component. The same physical USB
+ * cable used to flash the board carries the tuner traffic — no extra
+ * adapter required for ESP32-S2/S3/P4.
+ *
+ * Compiled into the espFoC component when CONFIG_ESP_FOC_BRIDGE_USBCDC
+ * is set.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void esp_foc_bridge_usbcdc_link_anchor(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/espFoC/esp_foc_link.h
+++ b/include/espFoC/esp_foc_link.h
@@ -1,0 +1,126 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+/**
+ * @file esp_foc_link.h
+ * @brief Wire-level framing for the espFoC tuner / scope protocols.
+ *
+ * Provides a transport-agnostic codec used by every bridge (USB-CDC,
+ * UART, TCP, ...). One frame on the wire looks like:
+ *
+ *   offset  bytes  field
+ *   -----   -----  -----
+ *   0       1      sync = 0xA5
+ *   1       2      payload_len (LE, max ESP_FOC_LINK_MAX_PAYLOAD)
+ *   3       1      channel  (see esp_foc_link_channel_t)
+ *   4       1      seq      (8-bit rolling, free for the caller)
+ *   5       N      payload  (N = payload_len)
+ *   5+N     2      crc16    (CRC-16/CCITT over channel..payload, LE)
+ *
+ * The codec itself is allocation-free, no-floating-point and re-entrant
+ * provided each call site uses its own state struct.
+ *
+ * Channels multiplex the same physical bus between the tuner request /
+ * response stream, the scope sample stream, and an optional log stream.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_FOC_LINK_SYNC          0xA5u
+#define ESP_FOC_LINK_HEADER_BYTES  5u   /* sync + len(2) + channel + seq */
+#define ESP_FOC_LINK_TRAILER_BYTES 2u   /* crc16 */
+#define ESP_FOC_LINK_MAX_PAYLOAD   256u
+#define ESP_FOC_LINK_MAX_FRAME     \
+    (ESP_FOC_LINK_HEADER_BYTES + ESP_FOC_LINK_MAX_PAYLOAD + ESP_FOC_LINK_TRAILER_BYTES)
+
+typedef enum {
+    ESP_FOC_LINK_CH_TUNER  = 0x01,  /* tuner request / response */
+    ESP_FOC_LINK_CH_SCOPE  = 0x02,  /* scope sample stream */
+    ESP_FOC_LINK_CH_LOG    = 0x03,  /* free-form log lines */
+} esp_foc_link_channel_t;
+
+typedef enum {
+    ESP_FOC_LINK_OK              = 0,
+    ESP_FOC_LINK_ERR_INVALID_ARG = -1,
+    ESP_FOC_LINK_ERR_TOO_BIG     = -2,
+    ESP_FOC_LINK_ERR_NEED_MORE   = -3,
+    ESP_FOC_LINK_ERR_BAD_SYNC    = -4,
+    ESP_FOC_LINK_ERR_BAD_CRC     = -5,
+} esp_foc_link_status_t;
+
+/**
+ * @brief Encode a single frame.
+ *
+ * @param channel       channel identifier (see esp_foc_link_channel_t)
+ * @param seq           caller-managed sequence byte
+ * @param payload       payload bytes (may be NULL when payload_len == 0)
+ * @param payload_len   payload length in bytes (max ESP_FOC_LINK_MAX_PAYLOAD)
+ * @param out           output buffer
+ * @param out_cap       output buffer capacity
+ * @param out_written   on success, total bytes written to @p out
+ *
+ * @return ESP_FOC_LINK_OK or a negative status.
+ */
+esp_foc_link_status_t esp_foc_link_encode(
+    esp_foc_link_channel_t channel,
+    uint8_t seq,
+    const uint8_t *payload, size_t payload_len,
+    uint8_t *out, size_t out_cap,
+    size_t *out_written);
+
+/* --- Streaming decoder ------------------------------------------------- */
+
+typedef struct {
+    /* Internal: never touched by the caller after init. */
+    uint8_t state;
+    uint8_t channel;
+    uint8_t seq;
+    uint16_t payload_len;
+    uint16_t payload_received;
+    uint16_t crc_recv;
+    uint16_t crc_calc;
+    uint8_t buf[ESP_FOC_LINK_MAX_PAYLOAD];
+} esp_foc_link_decoder_t;
+
+/* Initialise / reset a decoder before first use or after a fatal error. */
+void esp_foc_link_decoder_reset(esp_foc_link_decoder_t *dec);
+
+/**
+ * @brief Push a single byte into the streaming decoder.
+ *
+ * Returns ESP_FOC_LINK_OK when a full frame has been parsed (the caller
+ * then reads the channel/seq/payload from the corresponding accessors
+ * and resets the decoder). Returns ESP_FOC_LINK_ERR_NEED_MORE when more
+ * bytes are required, or one of the negative statuses on framing errors;
+ * any negative status implicitly resets the decoder.
+ */
+esp_foc_link_status_t esp_foc_link_decoder_push(
+    esp_foc_link_decoder_t *dec,
+    uint8_t byte);
+
+/* Accessors for the most recently completed frame. Valid only after
+ * esp_foc_link_decoder_push() returned ESP_FOC_LINK_OK and before the
+ * next call to push(). */
+uint8_t        esp_foc_link_decoder_channel(const esp_foc_link_decoder_t *dec);
+uint8_t        esp_foc_link_decoder_seq(const esp_foc_link_decoder_t *dec);
+const uint8_t *esp_foc_link_decoder_payload(const esp_foc_link_decoder_t *dec);
+size_t         esp_foc_link_decoder_payload_len(const esp_foc_link_decoder_t *dec);
+
+/* Exposed for golden tests and host-side mirror. CRC-16/CCITT, poly
+ * 0x1021, init 0xFFFF, no reflection, no xor-out. */
+uint16_t esp_foc_link_crc16(const uint8_t *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/espFoC/esp_foc_tuner.h
+++ b/include/espFoC/esp_foc_tuner.h
@@ -45,19 +45,35 @@ typedef enum {
 
 typedef enum {
     /* Read-only parameters */
-    ESP_FOC_TUNER_PARAM_KP_Q16          = 0x0010, /* read */
-    ESP_FOC_TUNER_PARAM_KI_Q16          = 0x0011, /* read */
-    ESP_FOC_TUNER_PARAM_INT_LIM_Q16     = 0x0012, /* read */
-    ESP_FOC_TUNER_PARAM_V_MAX_Q16       = 0x0013, /* read */
+    ESP_FOC_TUNER_PARAM_KP_Q16          = 0x0010, /* read q16 */
+    ESP_FOC_TUNER_PARAM_KI_Q16          = 0x0011, /* read q16 */
+    ESP_FOC_TUNER_PARAM_INT_LIM_Q16     = 0x0012, /* read q16 */
+    ESP_FOC_TUNER_PARAM_V_MAX_Q16       = 0x0013, /* read q16 */
+    ESP_FOC_TUNER_PARAM_AXIS_STATE      = 0x0040, /* read u8 bitmap */
+    ESP_FOC_TUNER_PARAM_AXIS_LAST_ERR   = 0x0041, /* read i8 (esp_foc_err_t) */
 
-    /* Write triggers an atomic gain swap on the target axis */
+    /* Write: gain swap (atomic) */
     ESP_FOC_TUNER_WRITE_KP_Q16          = 0x0020, /* write q16 */
     ESP_FOC_TUNER_WRITE_KI_Q16          = 0x0021, /* write q16 */
     ESP_FOC_TUNER_WRITE_INT_LIM_Q16     = 0x0022, /* write q16 */
 
-    /* Commands */
-    ESP_FOC_TUNER_CMD_RECOMPUTE_GAINS   = 0x0080, /* exec [R_q16,L_q16,bw_q16] */
+    /* Write: tuner-driven motion targets (only honored while override active) */
+    ESP_FOC_TUNER_WRITE_TARGET_ID_Q16   = 0x0050, /* write q16 (current ref) */
+    ESP_FOC_TUNER_WRITE_TARGET_IQ_Q16   = 0x0051, /* write q16 (current ref) */
+    ESP_FOC_TUNER_WRITE_TARGET_UD_Q16   = 0x0052, /* write q16 (voltage ff) */
+    ESP_FOC_TUNER_WRITE_TARGET_UQ_Q16   = 0x0053, /* write q16 (voltage ff) */
+
+    /* Commands (exec) */
+    ESP_FOC_TUNER_CMD_RECOMPUTE_GAINS   = 0x0080, /* [R_q16,L_q16,bw_q16] */
+    ESP_FOC_TUNER_CMD_OVERRIDE_ON       = 0x00A0, /* no payload */
+    ESP_FOC_TUNER_CMD_OVERRIDE_OFF      = 0x00A1, /* no payload */
 } esp_foc_tuner_id_t;
+
+/* Bitmap returned by ESP_FOC_TUNER_PARAM_AXIS_STATE. */
+#define ESP_FOC_AXIS_STATE_INITIALIZED    (1u << 0)
+#define ESP_FOC_AXIS_STATE_ALIGNED        (1u << 1)
+#define ESP_FOC_AXIS_STATE_RUNNING        (1u << 2)
+#define ESP_FOC_AXIS_STATE_TUNER_OVERRIDE (1u << 3)
 
 /**
  * @brief Register an axis under a stable id so the host can address it.

--- a/include/espFoC/esp_foc_tuner.h
+++ b/include/espFoC/esp_foc_tuner.h
@@ -108,6 +108,33 @@ esp_foc_err_t esp_foc_tuner_handle_request(
     void *response,
     size_t *response_len);
 
+/**
+ * @brief Drive the tuner with raw bytes from a transport reader.
+ *
+ * Bridges (UART, USB-CDC, ...) implement esp_foc_tuner_recv_callback() to
+ * pull bytes off the wire and feed them here one at a time. When a full
+ * tuner-channel frame is reassembled, it is dispatched to handle_request()
+ * and the encoded response is sent back via esp_foc_tuner_send_callback().
+ *
+ * The reactor maintains internal state across calls; do not interleave
+ * bytes coming from different physical buses.
+ *
+ * Application-level frame layout (inside the link payload):
+ *
+ *   request : [op:u8][id:u16 LE][axis:u8][cmd_payload:N]
+ *   response: [status:i8][seq:u8][resp_payload:N]
+ *
+ * The seq byte is echoed from the request frame's header so the host can
+ * match responses to outstanding requests.
+ */
+void esp_foc_tuner_process_byte(uint8_t byte);
+
+/**
+ * @brief Reset the reactor's link decoder. Useful after a transport
+ * disconnect / reconnect so a half-parsed frame does not leak across.
+ */
+void esp_foc_tuner_reactor_reset(void);
+
 /* Optional weak hooks for the user-defined transport layer.
  * The default no-op implementations let the protocol be exercised directly
  * via esp_foc_tuner_handle_request() without any I/O. */

--- a/source/drivers/esp_foc_bridge_uart.c
+++ b/source/drivers/esp_foc_bridge_uart.c
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+#include <sdkconfig.h>
+
+#if defined(CONFIG_ESP_FOC_BRIDGE_UART)
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "driver/uart.h"
+#include "espFoC/esp_foc_tuner.h"
+#include "espFoC/esp_foc_bridge_uart.h"
+
+static const char *TAG = "ESPFOC_BRIDGE_UART";
+
+#define UART_NUM           ((uart_port_t)CONFIG_ESP_FOC_BRIDGE_UART_NUM)
+#define UART_BAUD          (CONFIG_ESP_FOC_BRIDGE_UART_BAUD)
+#define UART_TX_PIN        (CONFIG_ESP_FOC_BRIDGE_UART_TX_PIN)
+#define UART_RX_PIN        (CONFIG_ESP_FOC_BRIDGE_UART_RX_PIN)
+#define UART_RX_BUFFER     2048
+#define UART_TX_BUFFER     1024
+#define READER_STACK_BYTES 4096
+
+static volatile bool s_bus_ready = false;
+
+static void reader_task(void *arg)
+{
+    (void)arg;
+    uint8_t buf[256];
+    while (1) {
+        int n = uart_read_bytes(UART_NUM, buf, sizeof(buf),
+                                pdMS_TO_TICKS(50));
+        if (n > 0) {
+            for (int i = 0; i < n; ++i) {
+                esp_foc_tuner_process_byte(buf[i]);
+            }
+        }
+    }
+}
+
+void esp_foc_tuner_init_bus_callback(void)
+{
+    if (s_bus_ready) {
+        return;
+    }
+    const uart_config_t cfg = {
+        .baud_rate = UART_BAUD,
+        .data_bits = UART_DATA_8_BITS,
+        .parity    = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .source_clk = UART_SCLK_DEFAULT,
+    };
+    ESP_ERROR_CHECK(uart_driver_install(UART_NUM, UART_RX_BUFFER, UART_TX_BUFFER,
+                                        0, NULL, 0));
+    ESP_ERROR_CHECK(uart_param_config(UART_NUM, &cfg));
+    ESP_ERROR_CHECK(uart_set_pin(UART_NUM, UART_TX_PIN, UART_RX_PIN,
+                                 UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE));
+    esp_foc_tuner_reactor_reset();
+    /* Cores fixed at 1; the reader task is light and shouldn't fight the
+     * control loop on PRO_CPU. Pinning is left to the user via xTaskCreate
+     * if they need a specific layout. */
+    BaseType_t ok = xTaskCreate(reader_task, "espfoc_uart_rx",
+                                READER_STACK_BYTES, NULL,
+                                tskIDLE_PRIORITY + 4, NULL);
+    if (ok != pdPASS) {
+        ESP_LOGE(TAG, "failed to spawn UART reader task");
+    }
+    s_bus_ready = true;
+    ESP_LOGI(TAG, "tuner UART bridge ready (UART%d, %d bps, TX=%d, RX=%d)",
+             (int)UART_NUM, UART_BAUD, UART_TX_PIN, UART_RX_PIN);
+}
+
+int esp_foc_tuner_recv_callback(uint8_t *buf, size_t max)
+{
+    if (buf == NULL || max == 0) {
+        return 0;
+    }
+    int n = uart_read_bytes(UART_NUM, buf, max, 0);
+    return (n < 0) ? 0 : n;
+}
+
+void esp_foc_tuner_send_callback(const uint8_t *buf, size_t len)
+{
+    if (buf == NULL || len == 0) {
+        return;
+    }
+    uart_write_bytes(UART_NUM, (const char *)buf, len);
+}
+
+void esp_foc_bridge_uart_link_anchor(void)
+{
+    /* Reference exported so a single TU pulls the bridge in even when the
+     * linker garbage-collects unused sections. */
+}
+
+#else  /* CONFIG_ESP_FOC_BRIDGE_UART not set */
+
+void esp_foc_bridge_uart_link_anchor(void) { }
+
+#endif

--- a/source/drivers/esp_foc_bridge_uart.c
+++ b/source/drivers/esp_foc_bridge_uart.c
@@ -12,6 +12,7 @@
 #include "freertos/task.h"
 #include "esp_log.h"
 #include "driver/uart.h"
+#include "espFoC/esp_foc_link.h"
 #include "espFoC/esp_foc_tuner.h"
 #include "espFoC/esp_foc_bridge_uart.h"
 
@@ -91,6 +92,42 @@ void esp_foc_tuner_send_callback(const uint8_t *buf, size_t len)
     }
     uart_write_bytes(UART_NUM, (const char *)buf, len);
 }
+
+#if defined(CONFIG_ESP_FOC_SCOPE)
+/* Shared code path with USB-CDC: wrap the scope's CSV payload in a
+ * SCOPE-channel link frame so the host can demux it alongside tuner
+ * responses on the same bus. seq rolls independently of the tuner. */
+static uint8_t s_scope_seq = 0;
+
+void esp_foc_init_bus_callback(void)
+{
+    /* Make sure the tuner path has initialised the UART. Idempotent. */
+    esp_foc_tuner_init_bus_callback();
+}
+
+void esp_foc_send_buffer_callback(const uint8_t *buffer, int size)
+{
+    if (buffer == NULL || size <= 0) {
+        return;
+    }
+    if ((size_t)size > ESP_FOC_LINK_MAX_PAYLOAD) {
+        /* Scope CSV overflowed the link MTU — drop the sample rather
+         * than risk splitting a CSV line across two frames. */
+        ESP_LOGW(TAG, "scope CSV %d > max %u, dropped",
+                 size, (unsigned)ESP_FOC_LINK_MAX_PAYLOAD);
+        return;
+    }
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t frame_len = 0;
+    esp_foc_link_status_t st = esp_foc_link_encode(
+        ESP_FOC_LINK_CH_SCOPE, s_scope_seq++, buffer, (size_t)size,
+        frame, sizeof(frame), &frame_len);
+    if (st != ESP_FOC_LINK_OK) {
+        return;
+    }
+    uart_write_bytes(UART_NUM, (const char *)frame, frame_len);
+}
+#endif
 
 void esp_foc_bridge_uart_link_anchor(void)
 {

--- a/source/drivers/esp_foc_bridge_usbcdc.c
+++ b/source/drivers/esp_foc_bridge_usbcdc.c
@@ -1,0 +1,106 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+#include <sdkconfig.h>
+
+#if defined(CONFIG_ESP_FOC_BRIDGE_USBCDC)
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "tinyusb.h"
+#include "tinyusb_default_config.h"
+#include "tinyusb_cdc_acm.h"
+#include "espFoC/esp_foc_tuner.h"
+#include "espFoC/esp_foc_bridge_usbcdc.h"
+
+static const char *TAG = "ESPFOC_BRIDGE_USB";
+#define READER_STACK_BYTES 4096
+
+static volatile bool s_bus_ready = false;
+
+/* TinyUSB delivers RX data from its own task via this callback. We forward
+ * each byte to the tuner reactor; the work is small enough to be done in
+ * place without bouncing through another queue. */
+static void rx_cb(int itf, cdcacm_event_t *event)
+{
+    (void)event;
+    uint8_t buf[64];
+    size_t n = 0;
+    if (tinyusb_cdcacm_read((tinyusb_cdcacm_itf_t)itf, buf, sizeof(buf), &n) != ESP_OK) {
+        return;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        esp_foc_tuner_process_byte(buf[i]);
+    }
+}
+
+static void line_state_cb(int itf, cdcacm_event_t *event)
+{
+    int dtr = event->line_state_changed_data.dtr;
+    int rts = event->line_state_changed_data.rts;
+    ESP_LOGI(TAG, "CDC line state: itf=%d DTR=%d RTS=%d", itf, dtr, rts);
+}
+
+void esp_foc_tuner_init_bus_callback(void)
+{
+    if (s_bus_ready) {
+        return;
+    }
+    const tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
+    ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
+
+    tinyusb_config_cdcacm_t acm_cfg = {
+        .cdc_port                     = TINYUSB_CDC_ACM_0,
+        .callback_rx                  = &rx_cb,
+        .callback_rx_wanted_char      = NULL,
+        .callback_line_state_changed  = NULL,
+        .callback_line_coding_changed = NULL,
+    };
+    ESP_ERROR_CHECK(tinyusb_cdcacm_init(&acm_cfg));
+    ESP_ERROR_CHECK(tinyusb_cdcacm_register_callback(
+                        TINYUSB_CDC_ACM_0,
+                        CDC_EVENT_LINE_STATE_CHANGED,
+                        &line_state_cb));
+
+    esp_foc_tuner_reactor_reset();
+    s_bus_ready = true;
+    ESP_LOGI(TAG, "tuner USB-CDC bridge ready");
+}
+
+int esp_foc_tuner_recv_callback(uint8_t *buf, size_t max)
+{
+    /* All ingress traffic is pushed by TinyUSB through rx_cb already; this
+     * shim exists only to satisfy the public API for callers that prefer
+     * polling over the push model. */
+    if (buf == NULL || max == 0) {
+        return 0;
+    }
+    size_t n = 0;
+    if (tinyusb_cdcacm_read(TINYUSB_CDC_ACM_0, buf, max, &n) != ESP_OK) {
+        return 0;
+    }
+    return (int)n;
+}
+
+void esp_foc_tuner_send_callback(const uint8_t *buf, size_t len)
+{
+    if (buf == NULL || len == 0) {
+        return;
+    }
+    tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, buf, len);
+    /* Short timeout: we never block the reactor for long; if the host is
+     * slow to drain its endpoint we drop newer bytes rather than stall. */
+    (void)tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, pdMS_TO_TICKS(20));
+}
+
+void esp_foc_bridge_usbcdc_link_anchor(void) { }
+
+#else /* CONFIG_ESP_FOC_BRIDGE_USBCDC not set */
+
+void esp_foc_bridge_usbcdc_link_anchor(void) { }
+
+#endif

--- a/source/drivers/esp_foc_bridge_usbcdc.c
+++ b/source/drivers/esp_foc_bridge_usbcdc.c
@@ -14,6 +14,7 @@
 #include "tinyusb.h"
 #include "tinyusb_default_config.h"
 #include "tinyusb_cdc_acm.h"
+#include "espFoC/esp_foc_link.h"
 #include "espFoC/esp_foc_tuner.h"
 #include "espFoC/esp_foc_bridge_usbcdc.h"
 
@@ -96,6 +97,39 @@ void esp_foc_tuner_send_callback(const uint8_t *buf, size_t len)
      * slow to drain its endpoint we drop newer bytes rather than stall. */
     (void)tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, pdMS_TO_TICKS(20));
 }
+
+#if defined(CONFIG_ESP_FOC_SCOPE)
+/* Mirror of the UART bridge: wrap scope CSV in a SCOPE-channel link
+ * frame so the host sees both streams demuxed on the same USB pipe. */
+static uint8_t s_scope_seq = 0;
+
+void esp_foc_init_bus_callback(void)
+{
+    esp_foc_tuner_init_bus_callback();
+}
+
+void esp_foc_send_buffer_callback(const uint8_t *buffer, int size)
+{
+    if (buffer == NULL || size <= 0) {
+        return;
+    }
+    if ((size_t)size > ESP_FOC_LINK_MAX_PAYLOAD) {
+        ESP_LOGW(TAG, "scope CSV %d > max %u, dropped",
+                 size, (unsigned)ESP_FOC_LINK_MAX_PAYLOAD);
+        return;
+    }
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t frame_len = 0;
+    esp_foc_link_status_t st = esp_foc_link_encode(
+        ESP_FOC_LINK_CH_SCOPE, s_scope_seq++, buffer, (size_t)size,
+        frame, sizeof(frame), &frame_len);
+    if (st != ESP_FOC_LINK_OK) {
+        return;
+    }
+    tinyusb_cdcacm_write_queue(TINYUSB_CDC_ACM_0, frame, frame_len);
+    (void)tinyusb_cdcacm_write_flush(TINYUSB_CDC_ACM_0, pdMS_TO_TICKS(20));
+}
+#endif
 
 void esp_foc_bridge_usbcdc_link_anchor(void) { }
 

--- a/source/motor_control/esp_foc_core.c
+++ b/source/motor_control/esp_foc_core.c
@@ -39,9 +39,31 @@ static void do_foc_outer_loop(void *arg)
 
     while (1) {
         esp_foc_wait_notifier();
-        if (axis->regulator_cb) {
-            axis->regulator_cb(axis, &axis->target_i_d, &axis->target_i_q, &axis->target_u_d, &axis->target_u_q);
+        if (axis->regulator_cb == NULL) {
+            continue;
         }
+#if defined(CONFIG_ESP_FOC_TUNER_ENABLE)
+        if (axis->tuner_override.active) {
+            /* Drain the user callback into shadow refs so its side effects
+             * (logging, sensor reads, state machines) keep firing — but the
+             * actual axis targets are owned by the tuner. Bumpless transfer
+             * back to user control happens automatically when the override
+             * flag clears. */
+            esp_foc_d_current_q16_t shadow_id;
+            esp_foc_q_current_q16_t shadow_iq;
+            esp_foc_d_voltage_q16_t shadow_ud;
+            esp_foc_q_voltage_q16_t shadow_uq;
+            axis->regulator_cb(axis, &shadow_id, &shadow_iq,
+                                     &shadow_ud, &shadow_uq);
+            axis->target_i_d.raw = axis->tuner_override.target_id;
+            axis->target_i_q.raw = axis->tuner_override.target_iq;
+            axis->target_u_d.raw = axis->tuner_override.target_ud;
+            axis->target_u_q.raw = axis->tuner_override.target_uq;
+            continue;
+        }
+#endif
+        axis->regulator_cb(axis, &axis->target_i_d, &axis->target_i_q,
+                                 &axis->target_u_d, &axis->target_u_q);
     }
 }
 
@@ -62,6 +84,15 @@ esp_foc_err_t esp_foc_initialize_axis(esp_foc_axis_t *axis,
         ESP_LOGE(tag, "invalid args for axis initialization");
         return ESP_FOC_ERR_INVALID_ARG;
     }
+
+#if defined(CONFIG_ESP_FOC_TUNER_ENABLE)
+    axis->magic = ESP_FOC_AXIS_MAGIC;
+    axis->tuner_override.active = false;
+    axis->tuner_override.target_id = 0;
+    axis->tuner_override.target_iq = 0;
+    axis->tuner_override.target_ud = 0;
+    axis->tuner_override.target_uq = 0;
+#endif
 
     axis->rotor_aligned = ESP_FOC_ERR_AXIS_INVALID_STATE;
     axis->inverter_driver = inverter;

--- a/source/motor_control/esp_foc_link.c
+++ b/source/motor_control/esp_foc_link.c
@@ -1,0 +1,211 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+#include <string.h>
+#include "espFoC/esp_foc_link.h"
+
+/* CRC-16/CCITT, polynomial 0x1021, init 0xFFFF, no reflection, no xor-out.
+ * Implemented bit-by-bit so the static footprint stays at zero (no LUT).
+ * Average frame is small enough that the throughput cost is negligible
+ * at typical link rates. */
+uint16_t esp_foc_link_crc16(const uint8_t *data, size_t len)
+{
+    uint16_t crc = 0xFFFFu;
+    if (data == NULL) {
+        return crc;
+    }
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= ((uint16_t)data[i]) << 8;
+        for (int b = 0; b < 8; ++b) {
+            if (crc & 0x8000u) {
+                crc = (uint16_t)((crc << 1) ^ 0x1021u);
+            } else {
+                crc = (uint16_t)(crc << 1);
+            }
+        }
+    }
+    return crc;
+}
+
+esp_foc_link_status_t esp_foc_link_encode(
+    esp_foc_link_channel_t channel,
+    uint8_t seq,
+    const uint8_t *payload, size_t payload_len,
+    uint8_t *out, size_t out_cap,
+    size_t *out_written)
+{
+    if (out == NULL || out_written == NULL) {
+        return ESP_FOC_LINK_ERR_INVALID_ARG;
+    }
+    if (payload_len > ESP_FOC_LINK_MAX_PAYLOAD) {
+        return ESP_FOC_LINK_ERR_TOO_BIG;
+    }
+    if (payload == NULL && payload_len > 0) {
+        return ESP_FOC_LINK_ERR_INVALID_ARG;
+    }
+
+    size_t total = ESP_FOC_LINK_HEADER_BYTES + payload_len + ESP_FOC_LINK_TRAILER_BYTES;
+    if (out_cap < total) {
+        return ESP_FOC_LINK_ERR_TOO_BIG;
+    }
+
+    out[0] = ESP_FOC_LINK_SYNC;
+    out[1] = (uint8_t)(payload_len & 0xFFu);
+    out[2] = (uint8_t)((payload_len >> 8) & 0xFFu);
+    out[3] = (uint8_t)channel;
+    out[4] = seq;
+    if (payload_len > 0) {
+        memcpy(&out[ESP_FOC_LINK_HEADER_BYTES], payload, payload_len);
+    }
+
+    /* CRC covers channel, seq and payload (everything past sync+len). */
+    uint16_t crc = esp_foc_link_crc16(&out[3], 2u + payload_len);
+    out[ESP_FOC_LINK_HEADER_BYTES + payload_len + 0] = (uint8_t)(crc & 0xFFu);
+    out[ESP_FOC_LINK_HEADER_BYTES + payload_len + 1] = (uint8_t)((crc >> 8) & 0xFFu);
+
+    *out_written = total;
+    return ESP_FOC_LINK_OK;
+}
+
+/* --- Streaming decoder ------------------------------------------------- */
+
+enum {
+    DEC_WAIT_SYNC = 0,
+    DEC_LEN_LO,
+    DEC_LEN_HI,
+    DEC_CHANNEL,
+    DEC_SEQ,
+    DEC_PAYLOAD,
+    DEC_CRC_LO,
+    DEC_CRC_HI,
+    DEC_DONE,
+};
+
+void esp_foc_link_decoder_reset(esp_foc_link_decoder_t *dec)
+{
+    if (dec == NULL) {
+        return;
+    }
+    dec->state = DEC_WAIT_SYNC;
+    dec->channel = 0;
+    dec->seq = 0;
+    dec->payload_len = 0;
+    dec->payload_received = 0;
+    dec->crc_recv = 0;
+    dec->crc_calc = 0xFFFFu;
+}
+
+/* Update the running CRC with a single byte. */
+static void crc16_update(uint16_t *crc, uint8_t byte)
+{
+    *crc ^= ((uint16_t)byte) << 8;
+    for (int b = 0; b < 8; ++b) {
+        if (*crc & 0x8000u) {
+            *crc = (uint16_t)((*crc << 1) ^ 0x1021u);
+        } else {
+            *crc = (uint16_t)(*crc << 1);
+        }
+    }
+}
+
+esp_foc_link_status_t esp_foc_link_decoder_push(
+    esp_foc_link_decoder_t *dec,
+    uint8_t byte)
+{
+    if (dec == NULL) {
+        return ESP_FOC_LINK_ERR_INVALID_ARG;
+    }
+
+    /* If a previous push completed a frame, reset before parsing new bytes. */
+    if (dec->state == DEC_DONE) {
+        esp_foc_link_decoder_reset(dec);
+    }
+
+    switch (dec->state) {
+    case DEC_WAIT_SYNC:
+        if (byte != ESP_FOC_LINK_SYNC) {
+            return ESP_FOC_LINK_ERR_NEED_MORE;
+        }
+        dec->state = DEC_LEN_LO;
+        return ESP_FOC_LINK_ERR_NEED_MORE;
+
+    case DEC_LEN_LO:
+        dec->payload_len = byte;
+        dec->state = DEC_LEN_HI;
+        return ESP_FOC_LINK_ERR_NEED_MORE;
+
+    case DEC_LEN_HI:
+        dec->payload_len |= ((uint16_t)byte) << 8;
+        if (dec->payload_len > ESP_FOC_LINK_MAX_PAYLOAD) {
+            esp_foc_link_decoder_reset(dec);
+            return ESP_FOC_LINK_ERR_TOO_BIG;
+        }
+        dec->state = DEC_CHANNEL;
+        return ESP_FOC_LINK_ERR_NEED_MORE;
+
+    case DEC_CHANNEL:
+        dec->channel = byte;
+        crc16_update(&dec->crc_calc, byte);
+        dec->state = DEC_SEQ;
+        return ESP_FOC_LINK_ERR_NEED_MORE;
+
+    case DEC_SEQ:
+        dec->seq = byte;
+        crc16_update(&dec->crc_calc, byte);
+        if (dec->payload_len == 0) {
+            dec->state = DEC_CRC_LO;
+        } else {
+            dec->state = DEC_PAYLOAD;
+        }
+        return ESP_FOC_LINK_ERR_NEED_MORE;
+
+    case DEC_PAYLOAD:
+        dec->buf[dec->payload_received++] = byte;
+        crc16_update(&dec->crc_calc, byte);
+        if (dec->payload_received >= dec->payload_len) {
+            dec->state = DEC_CRC_LO;
+        }
+        return ESP_FOC_LINK_ERR_NEED_MORE;
+
+    case DEC_CRC_LO:
+        dec->crc_recv = byte;
+        dec->state = DEC_CRC_HI;
+        return ESP_FOC_LINK_ERR_NEED_MORE;
+
+    case DEC_CRC_HI:
+        dec->crc_recv |= ((uint16_t)byte) << 8;
+        if (dec->crc_recv != dec->crc_calc) {
+            esp_foc_link_decoder_reset(dec);
+            return ESP_FOC_LINK_ERR_BAD_CRC;
+        }
+        dec->state = DEC_DONE;
+        return ESP_FOC_LINK_OK;
+
+    default:
+        esp_foc_link_decoder_reset(dec);
+        return ESP_FOC_LINK_ERR_BAD_SYNC;
+    }
+}
+
+uint8_t esp_foc_link_decoder_channel(const esp_foc_link_decoder_t *dec)
+{
+    return dec ? dec->channel : 0;
+}
+
+uint8_t esp_foc_link_decoder_seq(const esp_foc_link_decoder_t *dec)
+{
+    return dec ? dec->seq : 0;
+}
+
+const uint8_t *esp_foc_link_decoder_payload(const esp_foc_link_decoder_t *dec)
+{
+    return dec ? dec->buf : NULL;
+}
+
+size_t esp_foc_link_decoder_payload_len(const esp_foc_link_decoder_t *dec)
+{
+    return dec ? dec->payload_len : 0;
+}

--- a/source/motor_control/esp_foc_tuner.c
+++ b/source/motor_control/esp_foc_tuner.c
@@ -8,6 +8,7 @@
 #include "espFoC/esp_foc_tuner.h"
 #include "espFoC/esp_foc_axis_tuning.h"
 #include "espFoC/esp_foc_axis.h"
+#include "espFoC/esp_foc_link.h"
 
 /* Per-axis registry. Pointers are only mutated from esp_foc_tuner_attach_axis,
  * which is expected to be called from a non-time-critical context. */
@@ -248,6 +249,87 @@ esp_foc_err_t esp_foc_tuner_handle_request(
     default:
         return ESP_FOC_ERR_INVALID_ARG;
     }
+}
+
+/* --- Reactor: link decoder + dispatcher ------------------------------- */
+
+static esp_foc_link_decoder_t s_dec;
+static bool s_dec_initialized = false;
+
+void esp_foc_tuner_reactor_reset(void)
+{
+    esp_foc_link_decoder_reset(&s_dec);
+    s_dec_initialized = true;
+}
+
+static void send_response_frame(uint8_t seq,
+                                int8_t status,
+                                const uint8_t *resp_payload,
+                                size_t resp_len)
+{
+    /* Application-level response: [status:i8][seq:u8][payload]. The seq
+     * is echoed so the host can correlate responses to requests. */
+    uint8_t app[2 + ESP_FOC_LINK_MAX_PAYLOAD];
+    if (resp_len > sizeof(app) - 2) {
+        resp_len = sizeof(app) - 2;
+    }
+    app[0] = (uint8_t)status;
+    app[1] = seq;
+    if (resp_len > 0 && resp_payload != NULL) {
+        memcpy(&app[2], resp_payload, resp_len);
+    }
+
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t frame_len = 0;
+    if (esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, seq, app, 2 + resp_len,
+                            frame, sizeof(frame), &frame_len) != ESP_FOC_LINK_OK) {
+        return;
+    }
+    esp_foc_tuner_send_callback(frame, frame_len);
+}
+
+static void dispatch_frame(uint8_t seq,
+                           const uint8_t *payload,
+                           size_t payload_len)
+{
+    /* Application-level request: [op:u8][id:u16 LE][axis:u8][cmd_payload]. */
+    if (payload_len < 4) {
+        send_response_frame(seq, (int8_t)ESP_FOC_ERR_INVALID_ARG, NULL, 0);
+        return;
+    }
+    esp_foc_tuner_op_t op = (esp_foc_tuner_op_t)payload[0];
+    esp_foc_tuner_id_t id = (esp_foc_tuner_id_t)(payload[1] | ((uint16_t)payload[2] << 8));
+    uint8_t axis_id = payload[3];
+    const uint8_t *cmd_payload = payload + 4;
+    size_t cmd_len = payload_len - 4;
+
+    uint8_t resp_buf[8];
+    size_t  resp_len = sizeof(resp_buf);
+    esp_foc_err_t err = esp_foc_tuner_handle_request(axis_id, op, id,
+                                                     cmd_payload, cmd_len,
+                                                     resp_buf, &resp_len);
+    if (err != ESP_FOC_OK) {
+        resp_len = 0;
+    }
+    send_response_frame(seq, (int8_t)err, resp_buf, resp_len);
+}
+
+void esp_foc_tuner_process_byte(uint8_t byte)
+{
+    if (!s_dec_initialized) {
+        esp_foc_tuner_reactor_reset();
+    }
+    esp_foc_link_status_t st = esp_foc_link_decoder_push(&s_dec, byte);
+    if (st != ESP_FOC_LINK_OK) {
+        return;
+    }
+    if (esp_foc_link_decoder_channel(&s_dec) == ESP_FOC_LINK_CH_TUNER) {
+        dispatch_frame(esp_foc_link_decoder_seq(&s_dec),
+                       esp_foc_link_decoder_payload(&s_dec),
+                       esp_foc_link_decoder_payload_len(&s_dec));
+    }
+    /* Reset for the next frame. */
+    esp_foc_link_decoder_reset(&s_dec);
 }
 
 /* --- Default weak transport callbacks (no-op) -------------------------- */

--- a/source/motor_control/esp_foc_tuner.c
+++ b/source/motor_control/esp_foc_tuner.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include "espFoC/esp_foc_tuner.h"
 #include "espFoC/esp_foc_axis_tuning.h"
+#include "espFoC/esp_foc_axis.h"
 
 /* Per-axis registry. Pointers are only mutated from esp_foc_tuner_attach_axis,
  * which is expected to be called from a non-time-critical context. */
@@ -17,6 +18,11 @@ esp_foc_err_t esp_foc_tuner_attach_axis(uint8_t axis_id, esp_foc_axis_t *axis)
     if (axis_id >= ESP_FOC_TUNER_MAX_AXES) {
         return ESP_FOC_ERR_INVALID_ARG;
     }
+    /* NULL is allowed (detach); a non-NULL pointer must be a real,
+     * initialized axis so no later request operates on garbage memory. */
+    if (axis != NULL && axis->magic != ESP_FOC_AXIS_MAGIC) {
+        return ESP_FOC_ERR_AXIS_INVALID_STATE;
+    }
     s_axes[axis_id] = axis;
     return ESP_FOC_OK;
 }
@@ -26,7 +32,30 @@ static esp_foc_axis_t *get_axis(uint8_t axis_id)
     if (axis_id >= ESP_FOC_TUNER_MAX_AXES) {
         return NULL;
     }
-    return s_axes[axis_id];
+    esp_foc_axis_t *a = s_axes[axis_id];
+    if (a == NULL || a->magic != ESP_FOC_AXIS_MAGIC) {
+        return NULL;
+    }
+    return a;
+}
+
+static uint8_t compute_axis_state(const esp_foc_axis_t *axis)
+{
+    uint8_t s = 0;
+    if (axis->magic == ESP_FOC_AXIS_MAGIC) {
+        s |= ESP_FOC_AXIS_STATE_INITIALIZED;
+    }
+    if (axis->rotor_aligned == ESP_FOC_OK) {
+        s |= ESP_FOC_AXIS_STATE_ALIGNED;
+    }
+    /* esp_foc_run() spawns the outer-loop runner which sets regulator_ev. */
+    if (axis->regulator_ev != NULL) {
+        s |= ESP_FOC_AXIS_STATE_RUNNING;
+    }
+    if (axis->tuner_override.active) {
+        s |= ESP_FOC_AXIS_STATE_TUNER_OVERRIDE;
+    }
+    return s;
 }
 
 static void write_q16(void *dst, q16_t v)
@@ -54,7 +83,25 @@ static esp_foc_err_t handle_read(esp_foc_axis_t *axis,
                                  esp_foc_tuner_id_t id,
                                  void *response, size_t *response_len)
 {
-    if (response == NULL || response_len == NULL || *response_len < 4) {
+    if (response == NULL || response_len == NULL) {
+        return ESP_FOC_ERR_INVALID_ARG;
+    }
+
+    /* AXIS_STATE / AXIS_LAST_ERR return a single byte; everything else 4. */
+    if (id == ESP_FOC_TUNER_PARAM_AXIS_STATE ||
+        id == ESP_FOC_TUNER_PARAM_AXIS_LAST_ERR) {
+        if (*response_len < 1) {
+            return ESP_FOC_ERR_INVALID_ARG;
+        }
+        uint8_t *b = (uint8_t *)response;
+        b[0] = (id == ESP_FOC_TUNER_PARAM_AXIS_STATE)
+                 ? compute_axis_state(axis)
+                 : (uint8_t)(int8_t)axis->rotor_aligned;
+        *response_len = 1;
+        return ESP_FOC_OK;
+    }
+
+    if (*response_len < 4) {
         return ESP_FOC_ERR_INVALID_ARG;
     }
 
@@ -85,19 +132,45 @@ static esp_foc_err_t handle_write(esp_foc_axis_t *axis,
     }
     q16_t v = read_q16(payload);
 
-    /* All three values are written together: read current, swap one, push back.
-     * The set call performs the atomic swap so the PID never sees a partial
-     * update. */
-    q16_t kp, ki, lim;
-    esp_foc_axis_get_current_pi_gains_q16(axis, &kp, &ki, &lim);
-    switch (id) {
-    case ESP_FOC_TUNER_WRITE_KP_Q16:      kp  = v; break;
-    case ESP_FOC_TUNER_WRITE_KI_Q16:      ki  = v; break;
-    case ESP_FOC_TUNER_WRITE_INT_LIM_Q16: lim = v; break;
-    default:
-        return ESP_FOC_ERR_INVALID_ARG;
+    /* Gain writes feed the existing atomic swap helper so the PID never
+     * sees a partial update. */
+    if (id == ESP_FOC_TUNER_WRITE_KP_Q16 ||
+        id == ESP_FOC_TUNER_WRITE_KI_Q16 ||
+        id == ESP_FOC_TUNER_WRITE_INT_LIM_Q16) {
+        q16_t kp, ki, lim;
+        esp_foc_axis_get_current_pi_gains_q16(axis, &kp, &ki, &lim);
+        switch (id) {
+        case ESP_FOC_TUNER_WRITE_KP_Q16:      kp  = v; break;
+        case ESP_FOC_TUNER_WRITE_KI_Q16:      ki  = v; break;
+        case ESP_FOC_TUNER_WRITE_INT_LIM_Q16: lim = v; break;
+        default: break;
+        }
+        return esp_foc_axis_set_current_pi_gains_q16(axis, kp, ki, lim);
     }
-    return esp_foc_axis_set_current_pi_gains_q16(axis, kp, ki, lim);
+
+    /* Motion-target writes only land while the override is active.
+     * The four shadow targets are tiny so we use the global critical
+     * section for the swap. */
+    if (id == ESP_FOC_TUNER_WRITE_TARGET_ID_Q16 ||
+        id == ESP_FOC_TUNER_WRITE_TARGET_IQ_Q16 ||
+        id == ESP_FOC_TUNER_WRITE_TARGET_UD_Q16 ||
+        id == ESP_FOC_TUNER_WRITE_TARGET_UQ_Q16) {
+        if (!axis->tuner_override.active) {
+            return ESP_FOC_ERR_AXIS_INVALID_STATE;
+        }
+        esp_foc_critical_enter();
+        switch (id) {
+        case ESP_FOC_TUNER_WRITE_TARGET_ID_Q16: axis->tuner_override.target_id = v; break;
+        case ESP_FOC_TUNER_WRITE_TARGET_IQ_Q16: axis->tuner_override.target_iq = v; break;
+        case ESP_FOC_TUNER_WRITE_TARGET_UD_Q16: axis->tuner_override.target_ud = v; break;
+        case ESP_FOC_TUNER_WRITE_TARGET_UQ_Q16: axis->tuner_override.target_uq = v; break;
+        default: break;
+        }
+        esp_foc_critical_leave();
+        return ESP_FOC_OK;
+    }
+
+    return ESP_FOC_ERR_INVALID_ARG;
 }
 
 static esp_foc_err_t handle_exec(esp_foc_axis_t *axis,
@@ -114,6 +187,30 @@ static esp_foc_err_t handle_exec(esp_foc_axis_t *axis,
         q16_t bw = read_q16(p + 8);
         return esp_foc_axis_retune_current_pi_q16(axis, r, l, bw);
     }
+
+    if (id == ESP_FOC_TUNER_CMD_OVERRIDE_ON) {
+        /* Refuse to take over an axis that is not aligned: spinning a
+         * motor with an unaligned encoder produces wild currents. */
+        if (axis->rotor_aligned != ESP_FOC_OK) {
+            return ESP_FOC_ERR_NOT_ALIGNED;
+        }
+        esp_foc_critical_enter();
+        axis->tuner_override.target_id = 0;
+        axis->tuner_override.target_iq = 0;
+        axis->tuner_override.target_ud = 0;
+        axis->tuner_override.target_uq = 0;
+        axis->tuner_override.active = true;
+        esp_foc_critical_leave();
+        return ESP_FOC_OK;
+    }
+
+    if (id == ESP_FOC_TUNER_CMD_OVERRIDE_OFF) {
+        esp_foc_critical_enter();
+        axis->tuner_override.active = false;
+        esp_foc_critical_leave();
+        return ESP_FOC_OK;
+    }
+
     return ESP_FOC_ERR_INVALID_ARG;
 }
 

--- a/test/test_link.c
+++ b/test/test_link.c
@@ -1,0 +1,183 @@
+/*
+ * MIT License
+ *
+ * Unit tests for esp_foc_link (wire framing + CRC). Pure C, no transport.
+ */
+
+#include <string.h>
+#include <unity.h>
+#include "espFoC/esp_foc_link.h"
+
+static void encode_decode_roundtrip(esp_foc_link_channel_t channel,
+                                    uint8_t seq,
+                                    const uint8_t *payload, size_t len)
+{
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t written = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(channel, seq, payload, len,
+                            frame, sizeof(frame), &written));
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_HEADER_BYTES + len + ESP_FOC_LINK_TRAILER_BYTES,
+                      written);
+
+    esp_foc_link_decoder_t dec;
+    esp_foc_link_decoder_reset(&dec);
+
+    esp_foc_link_status_t st = ESP_FOC_LINK_ERR_NEED_MORE;
+    for (size_t i = 0; i < written; ++i) {
+        st = esp_foc_link_decoder_push(&dec, frame[i]);
+        if (i + 1 < written) {
+            TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_NEED_MORE, st);
+        }
+    }
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK, st);
+    TEST_ASSERT_EQUAL(channel, esp_foc_link_decoder_channel(&dec));
+    TEST_ASSERT_EQUAL(seq, esp_foc_link_decoder_seq(&dec));
+    TEST_ASSERT_EQUAL(len, esp_foc_link_decoder_payload_len(&dec));
+    if (len > 0) {
+        TEST_ASSERT_EQUAL_MEMORY(payload,
+                                 esp_foc_link_decoder_payload(&dec), len);
+    }
+}
+
+TEST_CASE("link: encode/decode round-trip on tiny payload",
+          "[espFoC][link]")
+{
+    const uint8_t pl[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    encode_decode_roundtrip(ESP_FOC_LINK_CH_TUNER, 0x42, pl, sizeof(pl));
+}
+
+TEST_CASE("link: encode/decode round-trip on empty payload",
+          "[espFoC][link]")
+{
+    encode_decode_roundtrip(ESP_FOC_LINK_CH_LOG, 0x00, NULL, 0);
+}
+
+TEST_CASE("link: encode/decode round-trip on max payload",
+          "[espFoC][link]")
+{
+    uint8_t pl[ESP_FOC_LINK_MAX_PAYLOAD];
+    for (size_t i = 0; i < sizeof(pl); ++i) {
+        pl[i] = (uint8_t)(i ^ 0x55);
+    }
+    encode_decode_roundtrip(ESP_FOC_LINK_CH_SCOPE, 0xFF, pl, sizeof(pl));
+}
+
+TEST_CASE("link: encode rejects oversized payload",
+          "[espFoC][link]")
+{
+    uint8_t out[ESP_FOC_LINK_MAX_FRAME];
+    uint8_t pl[ESP_FOC_LINK_MAX_PAYLOAD + 1] = {0};
+    size_t written = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_TOO_BIG,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, 0, pl, sizeof(pl),
+                            out, sizeof(out), &written));
+}
+
+TEST_CASE("link: encode rejects undersized output buffer",
+          "[espFoC][link]")
+{
+    uint8_t out[4];
+    uint8_t pl[1] = {0xAA};
+    size_t written = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_TOO_BIG,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, 0, pl, sizeof(pl),
+                            out, sizeof(out), &written));
+}
+
+TEST_CASE("link: decoder skips garbage until SYNC byte",
+          "[espFoC][link]")
+{
+    /* Pre-send a few bytes of "noise" before a valid frame. */
+    const uint8_t pl[] = {0x10, 0x20};
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t written = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, 7, pl, sizeof(pl),
+                            frame, sizeof(frame), &written));
+
+    esp_foc_link_decoder_t dec;
+    esp_foc_link_decoder_reset(&dec);
+
+    /* Garbage bytes — none are SYNC, so decoder must stay in WAIT_SYNC. */
+    const uint8_t garbage[] = {0x00, 0x11, 0xFF, 0x12, 0x34};
+    for (size_t i = 0; i < sizeof(garbage); ++i) {
+        TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_NEED_MORE,
+                          esp_foc_link_decoder_push(&dec, garbage[i]));
+    }
+
+    /* Now feed the real frame; should still parse correctly. */
+    esp_foc_link_status_t st = ESP_FOC_LINK_ERR_NEED_MORE;
+    for (size_t i = 0; i < written; ++i) {
+        st = esp_foc_link_decoder_push(&dec, frame[i]);
+    }
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK, st);
+    TEST_ASSERT_EQUAL(7, esp_foc_link_decoder_seq(&dec));
+}
+
+TEST_CASE("link: decoder flags CRC corruption", "[espFoC][link]")
+{
+    const uint8_t pl[] = {0xCA, 0xFE};
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t written = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_SCOPE, 1, pl, sizeof(pl),
+                            frame, sizeof(frame), &written));
+
+    /* Flip one CRC byte. */
+    frame[written - 1] ^= 0xFF;
+
+    esp_foc_link_decoder_t dec;
+    esp_foc_link_decoder_reset(&dec);
+    esp_foc_link_status_t st = ESP_FOC_LINK_ERR_NEED_MORE;
+    for (size_t i = 0; i < written; ++i) {
+        st = esp_foc_link_decoder_push(&dec, frame[i]);
+    }
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_BAD_CRC, st);
+}
+
+TEST_CASE("link: decoder recovers after a corrupt frame",
+          "[espFoC][link]")
+{
+    /* Bad frame followed by a good one: decoder must come back online. */
+    const uint8_t pl[] = {0x01, 0x02, 0x03};
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t written = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, 9, pl, sizeof(pl),
+                            frame, sizeof(frame), &written));
+
+    esp_foc_link_decoder_t dec;
+    esp_foc_link_decoder_reset(&dec);
+
+    /* Send a corrupt header (claims oversized payload). */
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_NEED_MORE,
+                      esp_foc_link_decoder_push(&dec, ESP_FOC_LINK_SYNC));
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_NEED_MORE,
+                      esp_foc_link_decoder_push(&dec, 0xFF));
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_ERR_TOO_BIG,
+                      esp_foc_link_decoder_push(&dec, 0xFF));
+
+    /* Decoder must be reset and now accept a valid frame. */
+    esp_foc_link_status_t st = ESP_FOC_LINK_ERR_NEED_MORE;
+    for (size_t i = 0; i < written; ++i) {
+        st = esp_foc_link_decoder_push(&dec, frame[i]);
+    }
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK, st);
+    TEST_ASSERT_EQUAL_MEMORY(pl, esp_foc_link_decoder_payload(&dec), sizeof(pl));
+}
+
+TEST_CASE("link: CRC-16/CCITT golden vectors", "[espFoC][link]")
+{
+    /* Reference values from independent computation. */
+    const uint8_t empty[] = {0};
+    TEST_ASSERT_EQUAL_HEX16(0xFFFFu, esp_foc_link_crc16(NULL, 0));
+    TEST_ASSERT_EQUAL_HEX16(0xFFFFu, esp_foc_link_crc16(empty, 0));
+
+    const uint8_t one[1] = {0x00};
+    TEST_ASSERT_EQUAL_HEX16(0xE1F0u, esp_foc_link_crc16(one, 1));
+
+    const uint8_t hello[5] = {'H','E','L','L','O'};
+    /* Pre-computed in a separate Python session for cross-val. */
+    TEST_ASSERT_EQUAL_HEX16(0x49D6u, esp_foc_link_crc16(hello, 5));
+}

--- a/test/test_tuner.c
+++ b/test/test_tuner.c
@@ -163,6 +163,145 @@ TEST_CASE("tuner: exec with short payload is rejected", "[espFoC][tuner]")
         payload, sizeof(payload), NULL, &resp_len));
 }
 
+/* --- magic / state query / motion / override --------------------------- */
+
+TEST_CASE("tuner: attach refuses an axis with no magic",
+          "[espFoC][tuner]")
+{
+    esp_foc_axis_t bogus;
+    memset(&bogus, 0, sizeof(bogus));
+    TEST_ASSERT_EQUAL(ESP_FOC_ERR_AXIS_INVALID_STATE,
+                      esp_foc_tuner_attach_axis(1, &bogus));
+}
+
+TEST_CASE("tuner: attach with NULL detaches without error",
+          "[espFoC][tuner]")
+{
+    setup_attached_axis();
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_attach_axis(0, NULL));
+    /* After detach all requests on this axis must be rejected. */
+    uint8_t resp = 0;
+    size_t resp_len = sizeof(resp);
+    TEST_ASSERT_EQUAL(ESP_FOC_ERR_INVALID_ARG, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_READ, ESP_FOC_TUNER_PARAM_AXIS_STATE,
+        NULL, 0, &resp, &resp_len));
+}
+
+TEST_CASE("tuner: read AXIS_STATE returns initialized + (un)aligned",
+          "[espFoC][tuner]")
+{
+    setup_attached_axis();
+    uint8_t resp = 0;
+    size_t resp_len = sizeof(resp);
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_READ, ESP_FOC_TUNER_PARAM_AXIS_STATE,
+        NULL, 0, &resp, &resp_len));
+    TEST_ASSERT_EQUAL_UINT(1, resp_len);
+    /* Axis was initialized but not aligned/run nor under override yet. */
+    TEST_ASSERT_TRUE(resp & ESP_FOC_AXIS_STATE_INITIALIZED);
+    TEST_ASSERT_FALSE(resp & ESP_FOC_AXIS_STATE_ALIGNED);
+    TEST_ASSERT_FALSE(resp & ESP_FOC_AXIS_STATE_RUNNING);
+    TEST_ASSERT_FALSE(resp & ESP_FOC_AXIS_STATE_TUNER_OVERRIDE);
+}
+
+TEST_CASE("tuner: override ON refused on un-aligned axis",
+          "[espFoC][tuner]")
+{
+    setup_attached_axis();
+    /* Fresh axis is not aligned yet; override must be rejected to keep the
+     * motor safe. */
+    size_t resp_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_ERR_NOT_ALIGNED, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_EXEC, ESP_FOC_TUNER_CMD_OVERRIDE_ON,
+        NULL, 0, NULL, &resp_len));
+}
+
+TEST_CASE("tuner: override ON then OFF flips state bit",
+          "[espFoC][tuner]")
+{
+    setup_attached_axis();
+    /* Manually mark the axis aligned (bypass real alignment for this unit
+     * test; align_axis needs hardware sequence). */
+    s_axis.rotor_aligned = ESP_FOC_OK;
+
+    size_t resp_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_EXEC, ESP_FOC_TUNER_CMD_OVERRIDE_ON,
+        NULL, 0, NULL, &resp_len));
+    uint8_t state = 0;
+    size_t rl = sizeof(state);
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_READ, ESP_FOC_TUNER_PARAM_AXIS_STATE,
+        NULL, 0, &state, &rl));
+    TEST_ASSERT_TRUE(state & ESP_FOC_AXIS_STATE_TUNER_OVERRIDE);
+
+    resp_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_EXEC, ESP_FOC_TUNER_CMD_OVERRIDE_OFF,
+        NULL, 0, NULL, &resp_len));
+    rl = sizeof(state);
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_READ, ESP_FOC_TUNER_PARAM_AXIS_STATE,
+        NULL, 0, &state, &rl));
+    TEST_ASSERT_FALSE(state & ESP_FOC_AXIS_STATE_TUNER_OVERRIDE);
+}
+
+TEST_CASE("tuner: motion target writes refused while override is OFF",
+          "[espFoC][tuner]")
+{
+    setup_attached_axis();
+    s_axis.rotor_aligned = ESP_FOC_OK;
+    /* override is OFF (default). Writing a motion target must fail. */
+    uint8_t payload[4];
+    serialize_q16_le(payload, q16_from_float(2.5f));
+    size_t resp_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_ERR_AXIS_INVALID_STATE,
+        esp_foc_tuner_handle_request(0, ESP_FOC_TUNER_OP_WRITE,
+            ESP_FOC_TUNER_WRITE_TARGET_IQ_Q16,
+            payload, sizeof(payload), NULL, &resp_len));
+}
+
+TEST_CASE("tuner: motion writes land in shadow when override is ON",
+          "[espFoC][tuner]")
+{
+    setup_attached_axis();
+    s_axis.rotor_aligned = ESP_FOC_OK;
+
+    size_t resp_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_EXEC, ESP_FOC_TUNER_CMD_OVERRIDE_ON,
+        NULL, 0, NULL, &resp_len));
+
+    q16_t targets[4] = {
+        q16_from_float(0.10f),  /* id */
+        q16_from_float(2.50f),  /* iq */
+        q16_from_float(0.30f),  /* ud */
+        q16_from_float(4.00f),  /* uq */
+    };
+    esp_foc_tuner_id_t ids[4] = {
+        ESP_FOC_TUNER_WRITE_TARGET_ID_Q16,
+        ESP_FOC_TUNER_WRITE_TARGET_IQ_Q16,
+        ESP_FOC_TUNER_WRITE_TARGET_UD_Q16,
+        ESP_FOC_TUNER_WRITE_TARGET_UQ_Q16,
+    };
+    for (int i = 0; i < 4; ++i) {
+        uint8_t pl[4];
+        serialize_q16_le(pl, targets[i]);
+        resp_len = 0;
+        TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+            0, ESP_FOC_TUNER_OP_WRITE, ids[i],
+            pl, sizeof(pl), NULL, &resp_len));
+    }
+
+    TEST_ASSERT_EQUAL_INT32(targets[0], s_axis.tuner_override.target_id);
+    TEST_ASSERT_EQUAL_INT32(targets[1], s_axis.tuner_override.target_iq);
+    TEST_ASSERT_EQUAL_INT32(targets[2], s_axis.tuner_override.target_ud);
+    TEST_ASSERT_EQUAL_INT32(targets[3], s_axis.tuner_override.target_uq);
+    /* Public targets stay zero — nothing happened to axis->target_* yet. */
+    TEST_ASSERT_EQUAL_INT32(0, s_axis.target_i_d.raw);
+    TEST_ASSERT_EQUAL_INT32(0, s_axis.target_i_q.raw);
+}
+
 #else
 
 /* Tuner disabled: keep this TU non-empty so the test build stays consistent. */

--- a/test/test_tuner_reactor.c
+++ b/test/test_tuner_reactor.c
@@ -1,0 +1,249 @@
+/*
+ * MIT License
+ *
+ * End-to-end tests for the tuner reactor: feed bytes into
+ * esp_foc_tuner_process_byte() and observe the response frame emitted via
+ * the (weakly defined) esp_foc_tuner_send_callback hook.
+ *
+ * Strongly overrides the weak callback so we can capture what the firmware
+ * would push onto the wire. Runs entirely in-process under QEMU with no
+ * physical transport.
+ */
+
+#include <string.h>
+#include <unity.h>
+#include "espFoC/esp_foc.h"
+#include "espFoC/esp_foc_tuner.h"
+#include "espFoC/esp_foc_axis_tuning.h"
+#include "espFoC/esp_foc_link.h"
+#include "espFoC/utils/esp_foc_q16.h"
+#include "mock_drivers.h"
+
+#if defined(CONFIG_ESP_FOC_TUNER_ENABLE)
+
+static esp_foc_axis_t s_axis;
+static mock_inverter_t s_inv;
+static mock_rotor_sensor_t s_rotor;
+static mock_isensor_t s_isensor;
+
+#define CAPTURE_CAP 256
+static uint8_t s_capture[CAPTURE_CAP];
+static size_t s_capture_len;
+
+void esp_foc_tuner_send_callback(const uint8_t *buf, size_t len)
+{
+    /* Append to the capture buffer. The protocol always answers with a
+     * single frame per request, so a 256-byte buffer is plenty. */
+    if (s_capture_len + len > sizeof(s_capture)) {
+        len = sizeof(s_capture) - s_capture_len;
+    }
+    memcpy(&s_capture[s_capture_len], buf, len);
+    s_capture_len += len;
+}
+
+static void setup_axis(void)
+{
+    esp_foc_motor_control_settings_t settings;
+    memset(&s_axis, 0, sizeof(s_axis));
+    mock_inverter_init(&s_inv, 1.0f, 20000.0f);
+    mock_rotor_sensor_init(&s_rotor, 4096.0f);
+    mock_isensor_init(&s_isensor);
+    settings.natural_direction = ESP_FOC_MOTOR_NATURAL_DIRECTION_CW;
+    settings.motor_pole_pairs = 7;
+    settings.motor_resistance = q16_from_float(1.0f);
+    settings.motor_inductance = q16_from_float(0.001f);
+    settings.motor_inertia = q16_from_float(0.0001f);
+    settings.motor_unit = 0;
+
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_initialize_axis(
+        &s_axis,
+        mock_inverter_interface(&s_inv),
+        mock_rotor_sensor_interface(&s_rotor),
+        mock_isensor_interface(&s_isensor),
+        settings));
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_attach_axis(0, &s_axis));
+    s_capture_len = 0;
+    esp_foc_tuner_reactor_reset();
+}
+
+/* Build an application-level request: [op:u8][id:u16 LE][axis:u8][cmd_payload]
+ * and wrap it in a tuner-channel link frame; push every byte through
+ * esp_foc_tuner_process_byte. */
+static void send_request(uint8_t seq,
+                         esp_foc_tuner_op_t op,
+                         esp_foc_tuner_id_t id,
+                         uint8_t axis_id,
+                         const uint8_t *cmd_payload,
+                         size_t cmd_payload_len)
+{
+    uint8_t app[ESP_FOC_LINK_MAX_PAYLOAD];
+    TEST_ASSERT_TRUE(4 + cmd_payload_len <= sizeof(app));
+    app[0] = (uint8_t)op;
+    app[1] = (uint8_t)((uint16_t)id & 0xFF);
+    app[2] = (uint8_t)(((uint16_t)id >> 8) & 0xFF);
+    app[3] = axis_id;
+    if (cmd_payload_len > 0) {
+        memcpy(&app[4], cmd_payload, cmd_payload_len);
+    }
+
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t frame_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, seq, app, 4 + cmd_payload_len,
+                            frame, sizeof(frame), &frame_len));
+
+    s_capture_len = 0;
+    for (size_t i = 0; i < frame_len; ++i) {
+        esp_foc_tuner_process_byte(frame[i]);
+    }
+}
+
+/* Decode the most recent response frame written into s_capture and pull
+ * the application status / payload out of it. */
+static esp_foc_err_t decode_response(uint8_t expected_seq,
+                                     uint8_t *resp_payload,
+                                     size_t  *resp_payload_len)
+{
+    esp_foc_link_decoder_t dec;
+    esp_foc_link_decoder_reset(&dec);
+    esp_foc_link_status_t st = ESP_FOC_LINK_ERR_NEED_MORE;
+    for (size_t i = 0; i < s_capture_len; ++i) {
+        st = esp_foc_link_decoder_push(&dec, s_capture[i]);
+    }
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK, st);
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_CH_TUNER, esp_foc_link_decoder_channel(&dec));
+    TEST_ASSERT_EQUAL(expected_seq, esp_foc_link_decoder_seq(&dec));
+    const uint8_t *app = esp_foc_link_decoder_payload(&dec);
+    size_t alen = esp_foc_link_decoder_payload_len(&dec);
+    TEST_ASSERT_TRUE(alen >= 2);  /* status + seq */
+    int8_t status = (int8_t)app[0];
+    TEST_ASSERT_EQUAL(expected_seq, app[1]);
+    if (resp_payload != NULL && resp_payload_len != NULL) {
+        size_t copy = alen - 2;
+        if (copy > *resp_payload_len) {
+            copy = *resp_payload_len;
+        }
+        memcpy(resp_payload, &app[2], copy);
+        *resp_payload_len = copy;
+    }
+    return (esp_foc_err_t)status;
+}
+
+/* --- Reactor tests ----------------------------------------------------- */
+
+TEST_CASE("reactor: read kp returns axis Kp through link frame",
+          "[espFoC][reactor]")
+{
+    setup_axis();
+    send_request(0x10, ESP_FOC_TUNER_OP_READ, ESP_FOC_TUNER_PARAM_KP_Q16,
+                 0, NULL, 0);
+
+    uint8_t payload[16];
+    size_t plen = sizeof(payload);
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, decode_response(0x10, payload, &plen));
+    TEST_ASSERT_EQUAL_UINT(4, plen);
+    /* Decode q16 LE and verify it matches the axis. */
+    int32_t got = (int32_t)((uint32_t)payload[0] |
+                            ((uint32_t)payload[1] << 8) |
+                            ((uint32_t)payload[2] << 16) |
+                            ((uint32_t)payload[3] << 24));
+    q16_t expected;
+    esp_foc_axis_get_current_pi_gains_q16(&s_axis, &expected, NULL, NULL);
+    TEST_ASSERT_EQUAL_INT32(expected, got);
+}
+
+TEST_CASE("reactor: write kp lands on axis", "[espFoC][reactor]")
+{
+    setup_axis();
+    q16_t target = q16_from_float(3.14f);
+    uint8_t cmd[4] = {
+        (uint8_t)target,
+        (uint8_t)(target >> 8),
+        (uint8_t)(target >> 16),
+        (uint8_t)(target >> 24),
+    };
+    send_request(0x55, ESP_FOC_TUNER_OP_WRITE, ESP_FOC_TUNER_WRITE_KP_Q16,
+                 0, cmd, sizeof(cmd));
+
+    size_t plen = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, decode_response(0x55, NULL, &plen));
+    q16_t got;
+    esp_foc_axis_get_current_pi_gains_q16(&s_axis, &got, NULL, NULL);
+    TEST_ASSERT_EQUAL_INT32(target, got);
+}
+
+TEST_CASE("reactor: short request payload returns INVALID_ARG",
+          "[espFoC][reactor]")
+{
+    setup_axis();
+    /* Build a frame whose application payload is too short (just 2 bytes). */
+    uint8_t app[2] = {0x01, 0x10};
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t frame_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, 0xAA, app, sizeof(app),
+                            frame, sizeof(frame), &frame_len));
+    s_capture_len = 0;
+    for (size_t i = 0; i < frame_len; ++i) {
+        esp_foc_tuner_process_byte(frame[i]);
+    }
+    TEST_ASSERT_EQUAL(ESP_FOC_ERR_INVALID_ARG, decode_response(0xAA, NULL, NULL));
+}
+
+TEST_CASE("reactor: scope-channel frame is silently ignored",
+          "[espFoC][reactor]")
+{
+    setup_axis();
+    /* Encode a scope-channel frame; the reactor must NOT respond. */
+    uint8_t pl[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t frame_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_SCOPE, 0, pl, sizeof(pl),
+                            frame, sizeof(frame), &frame_len));
+    s_capture_len = 0;
+    for (size_t i = 0; i < frame_len; ++i) {
+        esp_foc_tuner_process_byte(frame[i]);
+    }
+    TEST_ASSERT_EQUAL_UINT(0, s_capture_len);
+}
+
+TEST_CASE("reactor: corrupt CRC produces no response",
+          "[espFoC][reactor]")
+{
+    setup_axis();
+    /* Build a valid READ KP frame and then flip the last byte. */
+    uint8_t app[4] = {ESP_FOC_TUNER_OP_READ, 0x10, 0x00, 0};
+    uint8_t frame[ESP_FOC_LINK_MAX_FRAME];
+    size_t frame_len = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_LINK_OK,
+        esp_foc_link_encode(ESP_FOC_LINK_CH_TUNER, 0x07, app, sizeof(app),
+                            frame, sizeof(frame), &frame_len));
+    frame[frame_len - 1] ^= 0xFF;
+    s_capture_len = 0;
+    for (size_t i = 0; i < frame_len; ++i) {
+        esp_foc_tuner_process_byte(frame[i]);
+    }
+    TEST_ASSERT_EQUAL_UINT(0, s_capture_len);
+}
+
+TEST_CASE("reactor: exec recompute through link returns OK",
+          "[espFoC][reactor]")
+{
+    setup_axis();
+    q16_t r  = q16_from_float(1.08f);
+    q16_t l  = q16_from_float(0.0018f);
+    q16_t bw = q16_from_float(150.0f);
+    uint8_t cmd[12];
+    for (int i = 0; i < 4; ++i) {
+        cmd[i + 0] = (uint8_t)((uint32_t)r  >> (8 * i));
+        cmd[i + 4] = (uint8_t)((uint32_t)l  >> (8 * i));
+        cmd[i + 8] = (uint8_t)((uint32_t)bw >> (8 * i));
+    }
+    send_request(0x33, ESP_FOC_TUNER_OP_EXEC, ESP_FOC_TUNER_CMD_RECOMPUTE_GAINS,
+                 0, cmd, sizeof(cmd));
+    size_t plen = 0;
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, decode_response(0x33, NULL, &plen));
+}
+
+#endif /* CONFIG_ESP_FOC_TUNER_ENABLE */

--- a/tools/espfoc_studio/README.md
+++ b/tools/espfoc_studio/README.md
@@ -1,0 +1,73 @@
+# espfoc_studio
+
+Host-side tooling for the espFoC tuner stack. Three layers that share the
+same wire format as the firmware (see `source/motor_control/esp_foc_link.c`
+and `esp_foc_tuner.c`):
+
+- `espfoc_studio.link` — framing codec + transports (loopback, pyserial).
+- `espfoc_studio.protocol` — synchronous `TunerClient` for read / write /
+  exec round-trips (axis state, gains, motion targets, MPZ recompute).
+- `espfoc_studio.model` — analytical helpers (MPZ design, step response,
+  Bode, pole/zero, root locus). No Qt dependency.
+- `espfoc_studio.cli.tunerctl` — argparse CLI on top of TunerClient.
+- `espfoc_studio.gui` — PySide6 + pyqtgraph front-end (TunerStudio).
+
+## Install
+
+```bash
+pip install -r tools/espfoc_studio/requirements.txt
+```
+
+`PySide6` and `pyqtgraph` are only needed for the GUI; the CLI and the
+library layers work with just `pyserial` and `numpy`.
+
+## Try the GUI against a simulated firmware
+
+No hardware required — the `--demo` flag spawns an in-process
+`DemoFirmware` that speaks the same protocol a real board would:
+
+```bash
+PYTHONPATH=tools python3 -m espfoc_studio.gui --demo
+```
+
+The window opens with:
+
+- a **Tuning** panel on the left (live gains, manual edit, MPZ recompute,
+  override toggle, motion targets);
+- an **Analysis** tab that redraws the predicted step response, Bode
+  magnitude, pole/zero map and root locus every time the motor or gain
+  parameters change;
+- a **Scope** tab that streams the simulated plant response so you can
+  watch a step command converge in real time when the override is on.
+
+## Talk to real hardware
+
+Flash a firmware built with one of the bridges enabled
+(`CONFIG_ESP_FOC_BRIDGE_UART` or `CONFIG_ESP_FOC_BRIDGE_USBCDC`), then:
+
+```bash
+# UART or USB-CDC both come out as a plain serial device.
+PYTHONPATH=tools python3 -m espfoc_studio.gui --port /dev/ttyACM0
+```
+
+The CLI `tunerctl` works against the same bridges:
+
+```bash
+PYTHONPATH=tools python3 -m espfoc_studio.cli.tunerctl \
+    --port /dev/ttyACM0 axis-state
+
+PYTHONPATH=tools python3 -m espfoc_studio.cli.tunerctl \
+    --port /dev/ttyACM0 retune --r 1.08 --l 0.0018 --bw 150
+```
+
+## Run the host-side tests
+
+Each test file is standalone and exits with status 0 on success.
+
+```bash
+PYTHONPATH=tools python3 tools/espfoc_studio/tests/test_link_codec.py
+PYTHONPATH=tools python3 tools/espfoc_studio/tests/test_tuner_protocol.py
+PYTHONPATH=tools python3 tools/espfoc_studio/tests/test_analysis.py
+QT_QPA_PLATFORM=offscreen PYTHONPATH=tools \
+    python3 tools/espfoc_studio/tests/test_gui_smoke.py
+```

--- a/tools/espfoc_studio/__init__.py
+++ b/tools/espfoc_studio/__init__.py
@@ -1,0 +1,6 @@
+"""espfoc_studio — host-side tooling for the espFoC tuner stack.
+
+Currently exports the wire-level link codec (mirror of esp_foc_link.c).
+Subsequent PRs will add transports (USB-CDC, UART), tuner protocol,
+analysis library, CLI and GUI.
+"""

--- a/tools/espfoc_studio/cli/tunerctl.py
+++ b/tools/espfoc_studio/cli/tunerctl.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""tunerctl — talk to the espFoC tuner backend over a serial bus.
+
+Examples:
+
+    # Inspect the axis state
+    tunerctl --port /dev/ttyACM0 axis-state
+
+    # Read current PI gains
+    tunerctl --port /dev/ttyACM0 read
+
+    # Recompute gains via MPZ for a motor on the fly
+    tunerctl --port /dev/ttyACM0 retune --r 1.08 --l 0.0018 --bw 150
+
+    # Engage tuner override and command iq = 1.5 A
+    tunerctl --port /dev/ttyACM0 override on
+    tunerctl --port /dev/ttyACM0 set-target iq 1.5
+    tunerctl --port /dev/ttyACM0 override off
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+from ..link.transport_serial import SerialTransport
+from ..protocol import (
+    AxisStateFlag,
+    TunerClient,
+    TunerError,
+)
+
+
+def _format_state(s: AxisStateFlag) -> str:
+    pretty = []
+    for flag in (AxisStateFlag.INITIALIZED,
+                 AxisStateFlag.ALIGNED,
+                 AxisStateFlag.RUNNING,
+                 AxisStateFlag.TUNER_OVERRIDE):
+        pretty.append(f"{'+' if s & flag else '-'}{flag.name}")
+    return " ".join(pretty)
+
+
+def _make_client(args) -> TunerClient:
+    transport = SerialTransport(port=args.port, baud=args.baud)
+    return TunerClient(transport, axis=args.axis)
+
+
+def cmd_axis_state(args) -> int:
+    cli = _make_client(args)
+    state = cli.read_axis_state()
+    err = cli.read_last_error()
+    print(f"axis {args.axis}: state={int(state):#04x} ({_format_state(state)}) "
+          f"last_err={err}")
+    return 0
+
+
+def cmd_read(args) -> int:
+    cli = _make_client(args)
+    print(f"axis {args.axis}: "
+          f"Kp={cli.read_kp():.4f} V/A  "
+          f"Ki={cli.read_ki():.2f} V/(A*s)  "
+          f"ILim={cli.read_int_lim():.3f} V  "
+          f"Vmax={cli.read_v_max():.3f} V")
+    return 0
+
+
+def cmd_write(args) -> int:
+    cli = _make_client(args)
+    if args.kp is not None:
+        cli.write_kp(args.kp)
+    if args.ki is not None:
+        cli.write_ki(args.ki)
+    if args.ilim is not None:
+        cli.write_int_lim(args.ilim)
+    return cmd_read(args)
+
+
+def cmd_retune(args) -> int:
+    cli = _make_client(args)
+    cli.recompute_gains(args.r, args.l, args.bw)
+    return cmd_read(args)
+
+
+def cmd_override(args) -> int:
+    cli = _make_client(args)
+    if args.action == "on":
+        cli.override_on()
+    else:
+        cli.override_off()
+    return cmd_axis_state(args)
+
+
+def cmd_set_target(args) -> int:
+    cli = _make_client(args)
+    setter = {
+        "id": cli.write_target_id,
+        "iq": cli.write_target_iq,
+        "ud": cli.write_target_ud,
+        "uq": cli.write_target_uq,
+    }[args.target]
+    setter(args.value)
+    print(f"axis {args.axis}: target_{args.target}={args.value}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="tunerctl", description=__doc__)
+    p.add_argument("--port", required=True, help="serial port (e.g. /dev/ttyACM0)")
+    p.add_argument("--baud", type=int, default=921600, help="baud rate")
+    p.add_argument("--axis", type=int, default=0, help="axis id (0..3)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("axis-state", help="show axis state flags").set_defaults(func=cmd_axis_state)
+    sub.add_parser("read", help="read current PI gains + Vmax").set_defaults(func=cmd_read)
+
+    pw = sub.add_parser("write", help="manually override one or more gains")
+    pw.add_argument("--kp", type=float)
+    pw.add_argument("--ki", type=float)
+    pw.add_argument("--ilim", type=float)
+    pw.set_defaults(func=cmd_write)
+
+    pr = sub.add_parser("retune", help="recompute MPZ gains from motor params")
+    pr.add_argument("--r", type=float, required=True, help="phase resistance [ohm]")
+    pr.add_argument("--l", type=float, required=True, help="phase inductance [H]")
+    pr.add_argument("--bw", type=float, required=True, help="target bandwidth [Hz]")
+    pr.set_defaults(func=cmd_retune)
+
+    po = sub.add_parser("override", help="engage / release tuner motion control")
+    po.add_argument("action", choices=["on", "off"])
+    po.set_defaults(func=cmd_override)
+
+    ps = sub.add_parser("set-target", help="set a motion target (override must be ON)")
+    ps.add_argument("target", choices=["id", "iq", "ud", "uq"])
+    ps.add_argument("value", type=float)
+    ps.set_defaults(func=cmd_set_target)
+
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except TunerError as e:
+        print(f"tunerctl: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/espfoc_studio/gui/__init__.py
+++ b/tools/espfoc_studio/gui/__init__.py
@@ -1,0 +1,7 @@
+"""espfoc_studio.gui — PySide6 + pyqtgraph front-end for the tuner.
+
+Run with:
+
+    PYTHONPATH=tools python3 -m espfoc_studio.gui --demo
+    PYTHONPATH=tools python3 -m espfoc_studio.gui --port /dev/ttyACM0
+"""

--- a/tools/espfoc_studio/gui/__main__.py
+++ b/tools/espfoc_studio/gui/__main__.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 import argparse
 import signal
 import sys
-from typing import Callable, Optional
+from typing import Optional
 
-from ..link import LoopbackTransport
+from ..link import LinkReader, LoopbackTransport
 from ..protocol import TunerClient
 from .main_window import MainWindow
+from .theme import apply_dark_theme
 
 
 def _parse_args(argv: Optional[list[str]]) -> argparse.Namespace:
@@ -36,24 +37,37 @@ def _parse_args(argv: Optional[list[str]]) -> argparse.Namespace:
     return p.parse_args(argv)
 
 
-def _setup_demo() -> tuple[TunerClient, Callable[[], tuple[float, float, float]],
-                           Callable[[], None]]:
+def _setup_demo() -> tuple[TunerClient, Callable[[], None]]:
     from .demo_firmware import DemoFirmware
     host_t, fw_t = LoopbackTransport.pair()
     fw = DemoFirmware(fw_t)
     fw.start()
-    client = TunerClient(host_t)
-    return client, fw.snapshot_plant, fw.stop
+    # One reader, shared by the TunerClient and the ScopePanel (attached
+    # inside MainWindow). DemoFirmware streams scope frames over the
+    # same bus via the SCOPE channel.
+    reader = LinkReader(host_t)
+    reader.start()
+    client = TunerClient(reader)
+
+    def shutdown() -> None:
+        fw.stop()
+        reader.stop()
+
+    return client, shutdown
 
 
 def _setup_serial(port: str, baud: int, axis: int
-                  ) -> tuple[TunerClient, None, Callable[[], None]]:
+                  ) -> tuple[TunerClient, Callable[[], None]]:
     from ..link.transport_serial import SerialTransport
     transport = SerialTransport(port=port, baud=baud)
-    client = TunerClient(transport, axis=axis)
-    def _close() -> None:
-        transport.close()
-    return client, None, _close
+    reader = LinkReader(transport)
+    reader.start()
+    client = TunerClient(reader, axis=axis)
+
+    def shutdown() -> None:
+        reader.stop()
+
+    return client, shutdown
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -65,15 +79,15 @@ def main(argv: Optional[list[str]] = None) -> int:
     from PySide6.QtWidgets import QApplication
 
     if args.demo:
-        client, scope_source, shutdown = _setup_demo()
+        client, shutdown = _setup_demo()
         title = "espFoC TunerStudio — DEMO (simulated firmware)"
     else:
-        client, scope_source, shutdown = _setup_serial(args.port, args.baud,
-                                                       args.axis)
+        client, shutdown = _setup_serial(args.port, args.baud, args.axis)
         title = f"espFoC TunerStudio — {args.port} @ {args.baud}"
 
     app = QApplication.instance() or QApplication(sys.argv)
-    window = MainWindow(client, scope_source=scope_source, title=title)
+    apply_dark_theme(app)
+    window = MainWindow(client, title=title)
     window.show()
 
     # Allow Ctrl-C in the terminal to close the window.

--- a/tools/espfoc_studio/gui/__main__.py
+++ b/tools/espfoc_studio/gui/__main__.py
@@ -1,0 +1,93 @@
+"""Entry point for `python -m espfoc_studio.gui`.
+
+Two run modes:
+  --demo              Embedded DemoFirmware. Ideal for trying the GUI on
+                      a machine with no hardware attached. This is what
+                      the README's one-liner uses.
+  --port /dev/ttyX    Real serial transport (UART or USB-CDC bridge).
+
+Closing the window stops the demo threads and exits cleanly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import sys
+from typing import Callable, Optional
+
+from ..link import LoopbackTransport
+from ..protocol import TunerClient
+from .main_window import MainWindow
+
+
+def _parse_args(argv: Optional[list[str]]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="python -m espfoc_studio.gui",
+                                description=__doc__)
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--demo", action="store_true",
+                     help="spin an embedded DemoFirmware (no HW required)")
+    src.add_argument("--port",
+                     help="serial port of a real espFoC target (e.g. /dev/ttyACM0)")
+    p.add_argument("--baud", type=int, default=921600,
+                   help="baud rate when --port is used")
+    p.add_argument("--axis", type=int, default=0,
+                   help="axis id the GUI should attach to (0..3)")
+    return p.parse_args(argv)
+
+
+def _setup_demo() -> tuple[TunerClient, Callable[[], tuple[float, float, float]],
+                           Callable[[], None]]:
+    from .demo_firmware import DemoFirmware
+    host_t, fw_t = LoopbackTransport.pair()
+    fw = DemoFirmware(fw_t)
+    fw.start()
+    client = TunerClient(host_t)
+    return client, fw.snapshot_plant, fw.stop
+
+
+def _setup_serial(port: str, baud: int, axis: int
+                  ) -> tuple[TunerClient, None, Callable[[], None]]:
+    from ..link.transport_serial import SerialTransport
+    transport = SerialTransport(port=port, baud=baud)
+    client = TunerClient(transport, axis=axis)
+    def _close() -> None:
+        transport.close()
+    return client, None, _close
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    # Import Qt lazily so tests that only exercise the library layers do
+    # not have to pay the GUI import cost.
+    from PySide6.QtCore import QTimer
+    from PySide6.QtWidgets import QApplication
+
+    if args.demo:
+        client, scope_source, shutdown = _setup_demo()
+        title = "espFoC TunerStudio — DEMO (simulated firmware)"
+    else:
+        client, scope_source, shutdown = _setup_serial(args.port, args.baud,
+                                                       args.axis)
+        title = f"espFoC TunerStudio — {args.port} @ {args.baud}"
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    window = MainWindow(client, scope_source=scope_source, title=title)
+    window.show()
+
+    # Allow Ctrl-C in the terminal to close the window.
+    signal.signal(signal.SIGINT, lambda *_: app.quit())
+    # Qt ignores SIGINT while in exec(); a short QTimer drop-through keeps
+    # Python's signal handler serviced.
+    interrupt_tick = QTimer()
+    interrupt_tick.start(200)
+    interrupt_tick.timeout.connect(lambda: None)
+
+    exit_code = app.exec()
+    shutdown()
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/espfoc_studio/gui/analysis_panel.py
+++ b/tools/espfoc_studio/gui/analysis_panel.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pyqtgraph as pg
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QGridLayout, QLabel, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QGridLayout, QVBoxLayout, QWidget
 
 from ..model import (
     MotorParams,
@@ -27,14 +27,6 @@ class AnalysisPanel(QWidget):
         pg.setConfigOptions(antialias=True)
 
         root = QVBoxLayout(self)
-        heading = QLabel(
-            "Analytical views — recomputed whenever motor R/L/bandwidth "
-            "or manual gains change. Matches the firmware PI structure "
-            "(delayed forward-Euler) and ZOH plant.")
-        heading.setWordWrap(True)
-        heading.setAlignment(Qt.AlignLeft)
-        root.addWidget(heading)
-
         grid = QGridLayout()
         root.addLayout(grid, 1)
 

--- a/tools/espfoc_studio/gui/analysis_panel.py
+++ b/tools/espfoc_studio/gui/analysis_panel.py
@@ -15,6 +15,7 @@ from ..model import (
     root_locus,
     step_response,
 )
+from .crosshair import attach_crosshair
 
 
 class AnalysisPanel(QWidget):
@@ -36,6 +37,9 @@ class AnalysisPanel(QWidget):
         self._step_plot.showGrid(x=True, y=True, alpha=0.3)
         self._step_curve = self._step_plot.plot(pen=pg.mkPen('#2196f3', width=2))
         self._step_ref = self._step_plot.plot(pen=pg.mkPen('#888', style=Qt.DashLine))
+        self._step_crosshair = attach_crosshair(
+            self._step_plot,
+            fmt=lambda x, y: f"t = {x*1000:.2f} ms\ni = {y:+.4f} A")
 
         self._bode_mag = pg.PlotWidget(title="Open-loop gain |L(jω)|")
         self._bode_mag.setLabel('left', "Magnitude", units='dB')
@@ -43,12 +47,18 @@ class AnalysisPanel(QWidget):
         self._bode_mag.setLogMode(x=True, y=False)
         self._bode_mag.showGrid(x=True, y=True, alpha=0.3)
         self._bode_mag_curve = self._bode_mag.plot(pen=pg.mkPen('#00897b', width=2))
+        self._bode_crosshair = attach_crosshair(
+            self._bode_mag,
+            fmt=lambda x, y: f"f = {10.0**x:.1f} Hz\n|L| = {y:+.2f} dB")
 
         self._pz_plot = pg.PlotWidget(title="Pole / zero map")
         self._pz_plot.setAspectLocked(True)
         self._pz_plot.setLabel('left', "Im(z)")
         self._pz_plot.setLabel('bottom', "Re(z)")
         self._pz_plot.showGrid(x=True, y=True, alpha=0.3)
+        self._pz_crosshair = attach_crosshair(
+            self._pz_plot,
+            fmt=lambda x, y: f"Re = {x:+.3f}\nIm = {y:+.3f}")
         # Unit circle overlay.
         theta = np.linspace(0, 2 * np.pi, 361)
         self._pz_plot.plot(np.cos(theta), np.sin(theta),
@@ -69,6 +79,9 @@ class AnalysisPanel(QWidget):
         self._rl_plot.setLabel('left', "Im(z)")
         self._rl_plot.setLabel('bottom', "Re(z)")
         self._rl_plot.showGrid(x=True, y=True, alpha=0.3)
+        self._rl_crosshair = attach_crosshair(
+            self._rl_plot,
+            fmt=lambda x, y: f"Re = {x:+.3f}\nIm = {y:+.3f}")
         self._rl_plot.plot(np.cos(theta), np.sin(theta),
                            pen=pg.mkPen('#bdbdbd', width=1))
         self._rl_points = pg.ScatterPlotItem(size=6, pen=None,

--- a/tools/espfoc_studio/gui/analysis_panel.py
+++ b/tools/espfoc_studio/gui/analysis_panel.py
@@ -1,0 +1,143 @@
+"""Analysis panel: step response, Bode, pole-zero map, root locus."""
+
+from __future__ import annotations
+
+import numpy as np
+import pyqtgraph as pg
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QGridLayout, QLabel, QVBoxLayout, QWidget
+
+from ..model import (
+    MotorParams,
+    PiGains,
+    bode,
+    pole_zero_map,
+    root_locus,
+    step_response,
+)
+
+
+class AnalysisPanel(QWidget):
+    """Four plots driven off (R, L, bandwidth, Kp, Ki) emitted by the
+    tuning panel. Updates are cheap — all computations are O(thousands)
+    in numpy so they complete within a single event-loop tick."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        pg.setConfigOptions(antialias=True)
+
+        root = QVBoxLayout(self)
+        heading = QLabel(
+            "Analytical views — recomputed whenever motor R/L/bandwidth "
+            "or manual gains change. Matches the firmware PI structure "
+            "(delayed forward-Euler) and ZOH plant.")
+        heading.setWordWrap(True)
+        heading.setAlignment(Qt.AlignLeft)
+        root.addWidget(heading)
+
+        grid = QGridLayout()
+        root.addLayout(grid, 1)
+
+        self._step_plot = pg.PlotWidget(title="Predicted step response")
+        self._step_plot.setLabel('left', "i_q [A]")
+        self._step_plot.setLabel('bottom', "time", units='s')
+        self._step_plot.showGrid(x=True, y=True, alpha=0.3)
+        self._step_curve = self._step_plot.plot(pen=pg.mkPen('#2196f3', width=2))
+        self._step_ref = self._step_plot.plot(pen=pg.mkPen('#888', style=Qt.DashLine))
+
+        self._bode_mag = pg.PlotWidget(title="Open-loop gain |L(jω)|")
+        self._bode_mag.setLabel('left', "Magnitude", units='dB')
+        self._bode_mag.setLabel('bottom', "frequency", units='Hz')
+        self._bode_mag.setLogMode(x=True, y=False)
+        self._bode_mag.showGrid(x=True, y=True, alpha=0.3)
+        self._bode_mag_curve = self._bode_mag.plot(pen=pg.mkPen('#00897b', width=2))
+
+        self._pz_plot = pg.PlotWidget(title="Pole / zero map")
+        self._pz_plot.setAspectLocked(True)
+        self._pz_plot.setLabel('left', "Im(z)")
+        self._pz_plot.setLabel('bottom', "Re(z)")
+        self._pz_plot.showGrid(x=True, y=True, alpha=0.3)
+        # Unit circle overlay.
+        theta = np.linspace(0, 2 * np.pi, 361)
+        self._pz_plot.plot(np.cos(theta), np.sin(theta),
+                           pen=pg.mkPen('#bdbdbd', width=1))
+        self._pz_ol_pole_item = pg.ScatterPlotItem(
+            size=14, symbol='x', pen=pg.mkPen('#d81b60'), brush=None)
+        self._pz_ol_zero_item = pg.ScatterPlotItem(
+            size=12, symbol='o', pen=pg.mkPen('#1e88e5'), brush=None)
+        self._pz_cl_pole_item = pg.ScatterPlotItem(
+            size=14, symbol='x', pen=pg.mkPen('#000000'),
+            brush=None)
+        self._pz_plot.addItem(self._pz_ol_pole_item)
+        self._pz_plot.addItem(self._pz_ol_zero_item)
+        self._pz_plot.addItem(self._pz_cl_pole_item)
+
+        self._rl_plot = pg.PlotWidget(title="Root locus (Kp scale)")
+        self._rl_plot.setAspectLocked(True)
+        self._rl_plot.setLabel('left', "Im(z)")
+        self._rl_plot.setLabel('bottom', "Re(z)")
+        self._rl_plot.showGrid(x=True, y=True, alpha=0.3)
+        self._rl_plot.plot(np.cos(theta), np.sin(theta),
+                           pen=pg.mkPen('#bdbdbd', width=1))
+        self._rl_points = pg.ScatterPlotItem(size=6, pen=None,
+                                             brush=pg.mkBrush('#e65100'))
+        self._rl_plot.addItem(self._rl_points)
+
+        grid.addWidget(self._step_plot, 0, 0)
+        grid.addWidget(self._bode_mag,  0, 1)
+        grid.addWidget(self._pz_plot,   1, 0)
+        grid.addWidget(self._rl_plot,   1, 1)
+
+    def update_model(self, motor_r: float, motor_l: float, bw_hz: float,
+                     kp: float, ki: float) -> None:
+        """Re-render everything for the given operating point."""
+        try:
+            motor = MotorParams(r_ohm=motor_r, l_h=motor_l,
+                                ts_s=self._ts_s(), v_max=12.0)
+            gains = PiGains(kp=kp, ki=ki, int_lim=motor.v_max)
+        except ValueError:
+            return
+
+        # Step response.
+        try:
+            t, i = step_response(motor, gains, n_samples=400)
+            self._step_curve.setData(t, i)
+            self._step_ref.setData(t, np.ones_like(t))
+        except Exception:  # numerical blowup
+            pass
+
+        # Bode.
+        try:
+            f, mag, _phase = bode(motor, gains)
+            self._bode_mag_curve.setData(f, mag)
+        except Exception:
+            pass
+
+        # Pole / zero.
+        try:
+            ol_p, ol_z, cl_p, _cl_z = pole_zero_map(motor, gains)
+            self._pz_ol_pole_item.setData(pos=np.column_stack(
+                (ol_p.real, ol_p.imag)))
+            self._pz_ol_zero_item.setData(pos=np.column_stack(
+                (ol_z.real, ol_z.imag)))
+            self._pz_cl_pole_item.setData(pos=np.column_stack(
+                (cl_p.real, cl_p.imag)))
+        except Exception:
+            pass
+
+        # Root locus.
+        try:
+            _ks, mat = root_locus(motor, gains, scale_min=0.1,
+                                  scale_max=2.0, n_points=80)
+            flat = mat.flatten()
+            valid = ~np.isnan(flat.real)
+            self._rl_points.setData(pos=np.column_stack(
+                (flat[valid].real, flat[valid].imag)))
+        except Exception:
+            pass
+
+    def _ts_s(self) -> float:
+        """The GUI assumes the default loop period (1 ms). Real-firmware
+        mode will override this once the axis state query grows a Ts
+        field; for now we use the same value the demo firmware uses."""
+        return 0.001

--- a/tools/espfoc_studio/gui/crosshair.py
+++ b/tools/espfoc_studio/gui/crosshair.py
@@ -1,0 +1,102 @@
+"""Reusable crosshair + readout overlay for pyqtgraph PlotWidgets.
+
+Attaches a pair of InfiniteLines that follow the mouse, plus a small
+text label anchored to the upper-right corner of the plot showing the
+current (x, y) value in data coordinates. Works with linear and log
+scales and leaves the plot's normal interactions (pan, zoom) alone.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import pyqtgraph as pg
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+
+
+def _default_fmt(x: float, y: float) -> str:
+    return f"x = {x:+.4g}\ny = {y:+.4g}"
+
+
+class CrosshairOverlay:
+    """Adds a crosshair + text readout to a single PlotWidget."""
+
+    def __init__(self, plot: pg.PlotWidget,
+                 fmt: Optional[Callable[[float, float], str]] = None,
+                 color: str = "#9aa0a6") -> None:
+        self._plot = plot
+        self._fmt = fmt or _default_fmt
+        pen = pg.mkPen(QColor(color), width=1, style=Qt.DashLine)
+
+        self._vline = pg.InfiniteLine(angle=90, movable=False, pen=pen)
+        self._hline = pg.InfiniteLine(angle=0, movable=False, pen=pen)
+        for line in (self._vline, self._hline):
+            line.setZValue(10)
+            # Do not force the view to include the crosshair line —
+            # otherwise the plot autoscales to follow the mouse.
+            try:
+                line.setFlag(line.GraphicsItemFlag.ItemIgnoresTransformations, False)
+            except Exception:
+                pass
+            plot.addItem(line, ignoreBounds=True)
+
+        self._label = pg.TextItem(
+            text="", anchor=(0, 0),
+            color=QColor("#e6e6e6"),
+            fill=pg.mkBrush(QColor(0, 0, 0, 160)),
+            border=pg.mkPen(QColor("#3a3b3f")))
+        self._label.setZValue(11)
+        # Positioned lazily the first time the mouse enters the plot.
+        self._label_placed = False
+        plot.addItem(self._label, ignoreBounds=True)
+
+        self._hide_all()
+        plot.scene().sigMouseMoved.connect(self._on_moved)
+
+    def _hide_all(self) -> None:
+        self._vline.hide()
+        self._hline.hide()
+        self._label.hide()
+
+    def _show_all(self) -> None:
+        self._vline.show()
+        self._hline.show()
+        self._label.show()
+
+    def _place_label(self) -> None:
+        """Anchor the text to the upper-right corner of the view in
+        data coordinates. Called once the plot has a stable view box."""
+        vb = self._plot.getPlotItem().getViewBox()
+        rng = vb.viewRange()
+        x_hi, y_hi = rng[0][1], rng[1][1]
+        self._label.setPos(x_hi, y_hi)
+        self._label.setAnchor((1.05, 0))
+        self._label_placed = True
+
+    def _on_moved(self, scene_pos) -> None:
+        plot_item = self._plot.getPlotItem()
+        vb = plot_item.getViewBox()
+        if not vb.sceneBoundingRect().contains(scene_pos):
+            self._hide_all()
+            return
+        pt = vb.mapSceneToView(scene_pos)
+        x, y = float(pt.x()), float(pt.y())
+        self._vline.setPos(x)
+        self._hline.setPos(y)
+        if not self._label_placed:
+            self._place_label()
+        # Re-anchor every tick so the label stays in the top-right
+        # even as the view autoscales.
+        rng = vb.viewRange()
+        self._label.setPos(rng[0][1], rng[1][1])
+        self._label.setText(self._fmt(x, y))
+        self._show_all()
+
+def attach_crosshair(plot: pg.PlotWidget,
+                     fmt: Optional[Callable[[float, float], str]] = None,
+                     color: str = "#9aa0a6") -> CrosshairOverlay:
+    """Attach a CrosshairOverlay to *plot* and return it so the caller
+    can keep a reference (otherwise Python would garbage-collect it
+    and the connection would stop firing)."""
+    return CrosshairOverlay(plot, fmt=fmt, color=color)

--- a/tools/espfoc_studio/gui/demo_firmware.py
+++ b/tools/espfoc_studio/gui/demo_firmware.py
@@ -1,0 +1,237 @@
+"""Embedded "firmware" for GUI demo mode.
+
+Extends the protocol mirror used in tests/test_tuner_protocol.py with:
+  * full coverage of every tuner request the GUI issues
+  * a very simple plant simulation: first-order R-L model driven by the
+    current PID using the last commanded iq reference
+  * an MPZ recompute path that uses the authoritative espfoc_studio.model
+    so the GUI sees exactly the same gains the real firmware would
+    produce for the same motor parameters
+
+The firmware runs in its own daemon thread and is paired to the GUI via
+a LoopbackTransport. When the user drives a motion target through the
+override flow, the plant simulation settles toward it following the
+current closed-loop dynamics; this is what the scope panel plots.
+"""
+
+from __future__ import annotations
+
+import struct
+import threading
+import time
+from typing import Optional
+
+from ..link import Channel, Decoder, LoopbackTransport, Status, encode
+from ..model import MotorParams, PiGains, mpz_design
+from ..protocol import AxisStateFlag, Op, ParamId
+
+# Mirror of ESP_FOC_* status codes.
+OK = 0
+ERR_NOT_ALIGNED = -1
+ERR_INVALID_ARG = -2
+ERR_AXIS_INVALID_STATE = -3
+
+
+def _q16_to_bytes(v: float) -> bytes:
+    raw = max(-0x80000000, min(0x7FFFFFFF, round(v * 65536.0)))
+    return struct.pack("<i", raw)
+
+
+def _q16_from_bytes(b: bytes) -> float:
+    return struct.unpack("<i", b)[0] / 65536.0
+
+
+class DemoFirmware(threading.Thread):
+    """Fake firmware used by the GUI's --demo mode.
+
+    Internally keeps the full tuner state (gains, axis state, override)
+    plus a plant simulation that the scope panel can sample.
+    """
+
+    def __init__(self, transport: LoopbackTransport,
+                 motor: Optional[MotorParams] = None) -> None:
+        super().__init__(daemon=True, name="espfoc-demo-firmware")
+        self._t = transport
+        self._stop = threading.Event()
+        self._dec = Decoder()
+        self._state_lock = threading.Lock()
+
+        self.motor = motor or MotorParams(r_ohm=1.08, l_h=0.0018,
+                                          ts_s=0.001, v_max=12.0)
+        initial_gains = mpz_design(self.motor, bandwidth_hz=150.0)
+        self.kp = initial_gains.kp
+        self.ki = initial_gains.ki
+        self.lim = initial_gains.int_lim
+        self.aligned = True  # demo axis pretends it is ready to run
+        self.override = False
+        self.target_id = 0.0
+        self.target_iq = 0.0
+        self.target_ud = 0.0
+        self.target_uq = 0.0
+
+        # Plant state.
+        self._i_actual = 0.0
+        self._integ = 0.0
+        self._integ_prev = 0.0
+        self._sim_thread = threading.Thread(target=self._simulate,
+                                            daemon=True,
+                                            name="espfoc-demo-plant")
+
+    # --- Public helpers used by the GUI ------------------------------------
+
+    def snapshot_plant(self) -> tuple[float, float, float]:
+        """Return (target_iq, i_actual, time_s) for the scope panel."""
+        with self._state_lock:
+            return (self.target_iq, self._i_actual, time.monotonic())
+
+    # --- Thread lifecycle --------------------------------------------------
+
+    def start(self) -> None:  # type: ignore[override]
+        super().start()
+        self._sim_thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    # --- Simulation loop ---------------------------------------------------
+
+    def _simulate(self) -> None:
+        """Run the plant + PID at Ts. Matches the firmware closed-loop
+        enough for the scope to show sensible waveforms."""
+        import math
+        alpha = math.exp(-self.motor.r_ohm * self.motor.ts_s / self.motor.l_h)
+        while not self._stop.is_set():
+            with self._state_lock:
+                ref = self.target_iq if self.override else 0.0
+                err = ref - self._i_actual
+                u = self.kp * err + self._integ_prev
+                u = max(-self.motor.v_max, min(self.motor.v_max, u))
+                self._integ_prev = self._integ
+                self._integ += self.ki * err * self.motor.ts_s
+                if self.lim > 0:
+                    self._integ = max(-self.lim, min(self.lim, self._integ))
+                self._i_actual = (alpha * self._i_actual
+                                  + (1.0 - alpha) / self.motor.r_ohm * u)
+            time.sleep(self.motor.ts_s)
+
+    # --- Dispatcher --------------------------------------------------------
+
+    def run(self) -> None:  # type: ignore[override]
+        while not self._stop.is_set():
+            data = self._t.read_bytes(64, timeout=0.05)
+            if not data:
+                continue
+            for b in data:
+                st = self._dec.push(b)
+                if st == Status.OK:
+                    if self._dec.channel == int(Channel.TUNER):
+                        self._dispatch(self._dec.seq,
+                                       bytes(self._dec.payload))
+                    self._dec.reset()
+
+    def _send_response(self, seq: int, status: int,
+                       payload: bytes = b"") -> None:
+        body = struct.pack("<bB", status, seq) + payload
+        self._t.send_bytes(encode(Channel.TUNER, seq, body))
+
+    def _dispatch(self, seq: int, payload: bytes) -> None:
+        if len(payload) < 4:
+            self._send_response(seq, ERR_INVALID_ARG)
+            return
+        op = payload[0]
+        pid = payload[1] | (payload[2] << 8)
+        cmd = payload[4:]
+
+        with self._state_lock:
+            if op == int(Op.READ):
+                self._handle_read(seq, pid)
+            elif op == int(Op.WRITE):
+                self._handle_write(seq, pid, cmd)
+            elif op == int(Op.EXEC):
+                self._handle_exec(seq, pid, cmd)
+            else:
+                self._send_response(seq, ERR_INVALID_ARG)
+
+    def _handle_read(self, seq: int, pid: int) -> None:
+        if pid == int(ParamId.KP_Q16):
+            self._send_response(seq, OK, _q16_to_bytes(self.kp))
+        elif pid == int(ParamId.KI_Q16):
+            self._send_response(seq, OK, _q16_to_bytes(self.ki))
+        elif pid == int(ParamId.INT_LIM_Q16):
+            self._send_response(seq, OK, _q16_to_bytes(self.lim))
+        elif pid == int(ParamId.V_MAX_Q16):
+            self._send_response(seq, OK, _q16_to_bytes(self.motor.v_max))
+        elif pid == int(ParamId.AXIS_STATE):
+            flags = AxisStateFlag.INITIALIZED
+            if self.aligned:
+                flags |= AxisStateFlag.ALIGNED
+            if self.override:
+                flags |= AxisStateFlag.TUNER_OVERRIDE
+            self._send_response(seq, OK, bytes([int(flags)]))
+        elif pid == int(ParamId.AXIS_LAST_ERR):
+            self._send_response(seq, OK, struct.pack("<b", 0))
+        else:
+            self._send_response(seq, ERR_INVALID_ARG)
+
+    def _handle_write(self, seq: int, pid: int, cmd: bytes) -> None:
+        if len(cmd) < 4:
+            self._send_response(seq, ERR_INVALID_ARG)
+            return
+        v = _q16_from_bytes(cmd[:4])
+        if pid == int(ParamId.WRITE_KP):
+            self.kp = v
+            self._send_response(seq, OK)
+        elif pid == int(ParamId.WRITE_KI):
+            self.ki = v
+            self._send_response(seq, OK)
+        elif pid == int(ParamId.WRITE_INT_LIM):
+            self.lim = v
+            self._send_response(seq, OK)
+        elif pid in (int(ParamId.WRITE_TARGET_ID),
+                     int(ParamId.WRITE_TARGET_IQ),
+                     int(ParamId.WRITE_TARGET_UD),
+                     int(ParamId.WRITE_TARGET_UQ)):
+            if not self.override:
+                self._send_response(seq, ERR_AXIS_INVALID_STATE)
+                return
+            if pid == int(ParamId.WRITE_TARGET_ID): self.target_id = v
+            elif pid == int(ParamId.WRITE_TARGET_IQ): self.target_iq = v
+            elif pid == int(ParamId.WRITE_TARGET_UD): self.target_ud = v
+            else: self.target_uq = v
+            self._send_response(seq, OK)
+        else:
+            self._send_response(seq, ERR_INVALID_ARG)
+
+    def _handle_exec(self, seq: int, pid: int, cmd: bytes) -> None:
+        if pid == int(ParamId.CMD_OVERRIDE_ON):
+            if not self.aligned:
+                self._send_response(seq, ERR_NOT_ALIGNED)
+                return
+            self.override = True
+            self._send_response(seq, OK)
+        elif pid == int(ParamId.CMD_OVERRIDE_OFF):
+            self.override = False
+            self.target_id = 0.0
+            self.target_iq = 0.0
+            self._send_response(seq, OK)
+        elif pid == int(ParamId.CMD_RECOMPUTE_GAINS):
+            if len(cmd) < 12:
+                self._send_response(seq, ERR_INVALID_ARG)
+                return
+            r = _q16_from_bytes(cmd[0:4])
+            l = _q16_from_bytes(cmd[4:8])
+            bw = _q16_from_bytes(cmd[8:12])
+            try:
+                motor = MotorParams(r_ohm=r, l_h=l, ts_s=self.motor.ts_s,
+                                    v_max=self.motor.v_max)
+                g = mpz_design(motor, bw)
+            except ValueError:
+                self._send_response(seq, ERR_INVALID_ARG)
+                return
+            self.motor = motor
+            self.kp = g.kp
+            self.ki = g.ki
+            self.lim = g.int_lim
+            self._send_response(seq, OK)
+        else:
+            self._send_response(seq, ERR_INVALID_ARG)

--- a/tools/espfoc_studio/gui/demo_firmware.py
+++ b/tools/espfoc_studio/gui/demo_firmware.py
@@ -119,9 +119,20 @@ class DemoFirmware(threading.Thread):
         display_mag = max(abs(u_q_cmd), floor)
         if self.target_iq < 0:
             display_mag = -display_mag
-        u_u = display_mag * math.sin(angle)
-        u_v = display_mag * math.sin(angle - 2.0 * math.pi / 3.0)
-        u_w = display_mag * math.sin(angle + 2.0 * math.pi / 3.0)
+        # Pure three-phase sinusoids...
+        u_u_raw = display_mag * math.sin(angle)
+        u_v_raw = display_mag * math.sin(angle - 2.0 * math.pi / 3.0)
+        u_w_raw = display_mag * math.sin(angle + 2.0 * math.pi / 3.0)
+        # ... with the same min-max common-mode injection the real
+        # firmware SVPWM applies (source/motor_control/.../space_vector_
+        # modulator.h: v_cm = (max+min)/2; phases are shifted by -v_cm).
+        # This is what produces the characteristic "saddle" waveform
+        # that lets SVPWM push 15 % more DC bus than pure sine.
+        v_cm = 0.5 * (max(u_u_raw, u_v_raw, u_w_raw)
+                      + min(u_u_raw, u_v_raw, u_w_raw))
+        u_u = u_u_raw - v_cm
+        u_v = u_v_raw - v_cm
+        u_w = u_w_raw - v_cm
         fields = (u_u,             # ch0: SVPWM phase U (for hexagon)
                   u_v,             # ch1: SVPWM phase V
                   u_w,             # ch2: SVPWM phase W

--- a/tools/espfoc_studio/gui/demo_firmware.py
+++ b/tools/espfoc_studio/gui/demo_firmware.py
@@ -91,28 +91,43 @@ class DemoFirmware(threading.Thread):
 
     def _scope_frame_csv(self) -> bytes:
         """Reproduce the firmware's esp_foc_scope.c payload format:
-        comma-separated floats terminated with a newline. The number of
-        fields drives how many channels the GUI will display."""
-        alpha = 0.0
-        beta = 0.0
-        # Mimic a typical SVPWM triplet driven off the current u_q/u_d
-        # estimate. We cheat with a steady angle (0 rad) because this is a
-        # demo — the scope just needs realistic-looking waveforms.
+        comma-separated floats terminated with a newline.
+
+        Channel convention (shared with the real firmware):
+          ch0 = u_u, ch1 = u_v, ch2 = u_w  (SVPWM three-phase, for the
+                                            Hexagon view)
+          ch3 = target_iq, ch4 = i_q meas, ch5 = u_q command
+
+        The SVM panel reads channels 0/1/2 exclusively; ordering them
+        first gives the hexagon view a stable contract no matter how
+        many extra channels the application adds later.
+
+        On a real motor the SVPWM voltage vector keeps rotating at the
+        electrical speed even at steady state (back-EMF soaks up u_q).
+        Our demo plant has no mechanical model, so we synthesise a
+        visible steady-state magnitude from the active set-point to
+        mimic that rotation — otherwise the hexagon view would collapse
+        to the origin as soon as i_q reached its reference."""
         import math
         angle = (time.monotonic() * 2.0 * math.pi * 4.0) % (2.0 * math.pi)
-        u_q = self.kp * (self.target_iq - self._i_actual)
-        u_q = max(-self.motor.v_max, min(self.motor.v_max, u_q))
-        s = math.sin(angle)
-        c = math.cos(angle)
-        u_u = u_q * s
-        u_v = u_q * math.sin(angle - 2.0 * math.pi / 3.0)
-        u_w = u_q * math.sin(angle + 2.0 * math.pi / 3.0)
-        fields = (self.target_iq,  # ch0: ref
-                  self._i_actual,  # ch1: i_q measured
-                  u_q,             # ch2: u_q command
-                  u_u,             # ch3: SVPWM phase U
-                  u_v,             # ch4: SVPWM phase V
-                  u_w)             # ch5: SVPWM phase W
+        u_q_cmd = self.kp * (self.target_iq - self._i_actual)
+        u_q_cmd = max(-self.motor.v_max, min(self.motor.v_max, u_q_cmd))
+        # Visible magnitude: either the active loop effort or a fraction
+        # of the target current, whichever is larger. The sign tracks the
+        # reference so reversing iq swaps the vector direction.
+        floor = 0.3 * abs(self.target_iq) if self.override else 0.0
+        display_mag = max(abs(u_q_cmd), floor)
+        if self.target_iq < 0:
+            display_mag = -display_mag
+        u_u = display_mag * math.sin(angle)
+        u_v = display_mag * math.sin(angle - 2.0 * math.pi / 3.0)
+        u_w = display_mag * math.sin(angle + 2.0 * math.pi / 3.0)
+        fields = (u_u,             # ch0: SVPWM phase U (for hexagon)
+                  u_v,             # ch1: SVPWM phase V
+                  u_w,             # ch2: SVPWM phase W
+                  self.target_iq,  # ch3: current ref
+                  self._i_actual,  # ch4: i_q measured
+                  u_q_cmd)         # ch5: u_q command
         text = ",".join(f"{v:.6f}" for v in fields) + "\n"
         return text.encode("ascii")
 

--- a/tools/espfoc_studio/gui/demo_firmware.py
+++ b/tools/espfoc_studio/gui/demo_firmware.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Optional
 
-from ..link import Channel, Decoder, LoopbackTransport, Status, encode
+from ..link import Channel, Decoder, LoopbackTransport, MAX_PAYLOAD, Status, encode
 from ..model import MotorParams, PiGains, mpz_design
 from ..protocol import AxisStateFlag, Op, ParamId
 
@@ -84,6 +84,38 @@ class DemoFirmware(threading.Thread):
         with self._state_lock:
             return (self.target_iq, self._i_actual, time.monotonic())
 
+    # Configurable set of channels the demo streams on the SCOPE channel.
+    # The firmware's esp_foc_scope.c emits CSV text as the payload; we do
+    # the same here so the host-side ScopePanel can share the parser.
+    SCOPE_DECIMATION = 4  # one scope frame every N control steps (Ts = 1 ms)
+
+    def _scope_frame_csv(self) -> bytes:
+        """Reproduce the firmware's esp_foc_scope.c payload format:
+        comma-separated floats terminated with a newline. The number of
+        fields drives how many channels the GUI will display."""
+        alpha = 0.0
+        beta = 0.0
+        # Mimic a typical SVPWM triplet driven off the current u_q/u_d
+        # estimate. We cheat with a steady angle (0 rad) because this is a
+        # demo — the scope just needs realistic-looking waveforms.
+        import math
+        angle = (time.monotonic() * 2.0 * math.pi * 4.0) % (2.0 * math.pi)
+        u_q = self.kp * (self.target_iq - self._i_actual)
+        u_q = max(-self.motor.v_max, min(self.motor.v_max, u_q))
+        s = math.sin(angle)
+        c = math.cos(angle)
+        u_u = u_q * s
+        u_v = u_q * math.sin(angle - 2.0 * math.pi / 3.0)
+        u_w = u_q * math.sin(angle + 2.0 * math.pi / 3.0)
+        fields = (self.target_iq,  # ch0: ref
+                  self._i_actual,  # ch1: i_q measured
+                  u_q,             # ch2: u_q command
+                  u_u,             # ch3: SVPWM phase U
+                  u_v,             # ch4: SVPWM phase V
+                  u_w)             # ch5: SVPWM phase W
+        text = ",".join(f"{v:.6f}" for v in fields) + "\n"
+        return text.encode("ascii")
+
     # --- Thread lifecycle --------------------------------------------------
 
     def start(self) -> None:  # type: ignore[override]
@@ -97,9 +129,13 @@ class DemoFirmware(threading.Thread):
 
     def _simulate(self) -> None:
         """Run the plant + PID at Ts. Matches the firmware closed-loop
-        enough for the scope to show sensible waveforms."""
+        enough for the scope to show sensible waveforms, and pushes a
+        SCOPE-channel frame every SCOPE_DECIMATION steps so the host
+        gets a live stream just like it would from a real bridge."""
         import math
         alpha = math.exp(-self.motor.r_ohm * self.motor.ts_s / self.motor.l_h)
+        counter = 0
+        seq = 0
         while not self._stop.is_set():
             with self._state_lock:
                 ref = self.target_iq if self.override else 0.0
@@ -112,6 +148,17 @@ class DemoFirmware(threading.Thread):
                     self._integ = max(-self.lim, min(self.lim, self._integ))
                 self._i_actual = (alpha * self._i_actual
                                   + (1.0 - alpha) / self.motor.r_ohm * u)
+            counter += 1
+            if counter >= self.SCOPE_DECIMATION:
+                counter = 0
+                payload = self._scope_frame_csv()
+                if len(payload) <= MAX_PAYLOAD:
+                    try:
+                        self._t.send_bytes(
+                            encode(Channel.SCOPE, seq & 0xFF, payload))
+                    except Exception:
+                        pass
+                    seq = (seq + 1) & 0xFF
             time.sleep(self.motor.ts_s)
 
     # --- Dispatcher --------------------------------------------------------

--- a/tools/espfoc_studio/gui/main_window.py
+++ b/tools/espfoc_studio/gui/main_window.py
@@ -42,6 +42,17 @@ class MainWindow(QMainWindow):
         self._analysis = AnalysisPanel()
         self._scope = ScopePanel(scope_source)
 
+        # Analysis plots are expensive (step sim + bode + root locus).
+        # Debounce spinbox storms so one nudge of the mouse wheel doesn't
+        # fire a dozen full recomputes back-to-back. Must be created
+        # BEFORE the TuningPanel because the panel primes an initial
+        # _on_params call during construction.
+        self._analysis_pending = None
+        self._analysis_debounce = QTimer(self)
+        self._analysis_debounce.setSingleShot(True)
+        self._analysis_debounce.setInterval(150)
+        self._analysis_debounce.timeout.connect(self._run_pending_analysis)
+
         self._tuning = TuningPanel(client, on_params_changed=self._on_params)
         splitter.addWidget(self._tuning)
 
@@ -53,13 +64,16 @@ class MainWindow(QMainWindow):
         splitter.setStretchFactor(1, 1)
         splitter.setSizes([380, 900])
 
-        # Single polling timer drives everything needing periodic refresh.
+        # Live gains readout — every 500 ms is plenty for human perception
+        # and leaves headroom for the 50 FPS scope. Each poll issues five
+        # short tuner round-trips; 0.5 s keeps CPU usage near the noise
+        # floor on real serial links.
         self._timer = QTimer(self)
-        self._timer.setInterval(200)
+        self._timer.setInterval(500)
         self._timer.timeout.connect(self._poll)
         self._timer.start()
 
-        # Scope samples faster to show waveform detail.
+        # Scope samples at ~50 FPS for smooth waveforms in --demo mode.
         self._scope_timer = QTimer(self)
         self._scope_timer.setInterval(20)
         self._scope_timer.timeout.connect(self._scope.poll)
@@ -73,4 +87,12 @@ class MainWindow(QMainWindow):
 
     def _on_params(self, r: float, l: float, bw: float,
                    kp: float, ki: float) -> None:
+        self._analysis_pending = (r, l, bw, kp, ki)
+        self._analysis_debounce.start()
+
+    def _run_pending_analysis(self) -> None:
+        if self._analysis_pending is None:
+            return
+        r, l, bw, kp, ki = self._analysis_pending
+        self._analysis_pending = None
         self._analysis.update_model(r, l, bw, kp, ki)

--- a/tools/espfoc_studio/gui/main_window.py
+++ b/tools/espfoc_studio/gui/main_window.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 from ..protocol import TunerClient
 from .analysis_panel import AnalysisPanel
 from .scope_panel import ScopePanel
+from .svm_panel import SvmPanel
 from .tuning_panel import TuningPanel
 
 
@@ -35,9 +36,11 @@ class MainWindow(QMainWindow):
         root.addWidget(splitter, 1)
 
         self._analysis = AnalysisPanel()
-        # The scope listens on the shared LinkReader for SCOPE frames;
-        # no more poll-based shim.
+        # The scope and the SVM hexagon both subscribe to the same shared
+        # LinkReader. ch0/1/2 are (by convention) the three-phase SVPWM
+        # voltages, which the SVM panel reads exclusively.
         self._scope = ScopePanel(reader=client.reader)
+        self._svm = SvmPanel(reader=client.reader)
 
         # Analysis plots are expensive (step sim + bode + root locus).
         # Debounce spinbox storms so one nudge of the mouse wheel doesn't
@@ -56,6 +59,7 @@ class MainWindow(QMainWindow):
         tabs = QTabWidget()
         tabs.addTab(self._analysis, "Analysis")
         tabs.addTab(self._scope, "Scope")
+        tabs.addTab(self._svm, "SVM Hexagon")
         splitter.addWidget(tabs)
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)

--- a/tools/espfoc_studio/gui/main_window.py
+++ b/tools/espfoc_studio/gui/main_window.py
@@ -1,0 +1,76 @@
+"""Main window: assembles Tuning + Analysis + Scope into a single view
+and owns the single polling timer that keeps the live panels fresh."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from PySide6.QtCore import QTimer, Qt
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QSplitter,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..protocol import TunerClient
+from .analysis_panel import AnalysisPanel
+from .scope_panel import ScopePanel
+from .tuning_panel import TuningPanel
+
+
+class MainWindow(QMainWindow):
+    def __init__(self, client: TunerClient,
+                 scope_source: Optional[Callable[[],
+                                                 tuple[float, float, float]]]
+                 = None,
+                 title: str = "espFoC TunerStudio") -> None:
+        super().__init__()
+        self.setWindowTitle(title)
+        self.resize(1280, 800)
+
+        central = QWidget()
+        self.setCentralWidget(central)
+        root = QHBoxLayout(central)
+
+        splitter = QSplitter(Qt.Horizontal)
+        root.addWidget(splitter, 1)
+
+        self._analysis = AnalysisPanel()
+        self._scope = ScopePanel(scope_source)
+
+        self._tuning = TuningPanel(client, on_params_changed=self._on_params)
+        splitter.addWidget(self._tuning)
+
+        tabs = QTabWidget()
+        tabs.addTab(self._analysis, "Analysis")
+        tabs.addTab(self._scope, "Scope")
+        splitter.addWidget(tabs)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([380, 900])
+
+        # Single polling timer drives everything needing periodic refresh.
+        self._timer = QTimer(self)
+        self._timer.setInterval(200)
+        self._timer.timeout.connect(self._poll)
+        self._timer.start()
+
+        # Scope samples faster to show waveform detail.
+        self._scope_timer = QTimer(self)
+        self._scope_timer.setInterval(20)
+        self._scope_timer.timeout.connect(self._scope.poll)
+        self._scope_timer.start()
+
+        # Prime the analysis view with the initial spinbox values.
+        self._tuning._notify_params_changed()
+
+    def _poll(self) -> None:
+        self._tuning.poll()
+
+    def _on_params(self, r: float, l: float, bw: float,
+                   kp: float, ki: float) -> None:
+        self._analysis.update_model(r, l, bw, kp, ki)

--- a/tools/espfoc_studio/gui/main_window.py
+++ b/tools/espfoc_studio/gui/main_window.py
@@ -3,16 +3,14 @@ and owns the single polling timer that keeps the live panels fresh."""
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Optional
 
 from PySide6.QtCore import QTimer, Qt
 from PySide6.QtWidgets import (
     QHBoxLayout,
-    QLabel,
     QMainWindow,
     QSplitter,
     QTabWidget,
-    QVBoxLayout,
     QWidget,
 )
 
@@ -24,9 +22,6 @@ from .tuning_panel import TuningPanel
 
 class MainWindow(QMainWindow):
     def __init__(self, client: TunerClient,
-                 scope_source: Optional[Callable[[],
-                                                 tuple[float, float, float]]]
-                 = None,
                  title: str = "espFoC TunerStudio") -> None:
         super().__init__()
         self.setWindowTitle(title)
@@ -40,7 +35,9 @@ class MainWindow(QMainWindow):
         root.addWidget(splitter, 1)
 
         self._analysis = AnalysisPanel()
-        self._scope = ScopePanel(scope_source)
+        # The scope listens on the shared LinkReader for SCOPE frames;
+        # no more poll-based shim.
+        self._scope = ScopePanel(reader=client.reader)
 
         # Analysis plots are expensive (step sim + bode + root locus).
         # Debounce spinbox storms so one nudge of the mouse wheel doesn't
@@ -72,12 +69,6 @@ class MainWindow(QMainWindow):
         self._timer.setInterval(500)
         self._timer.timeout.connect(self._poll)
         self._timer.start()
-
-        # Scope samples at ~50 FPS for smooth waveforms in --demo mode.
-        self._scope_timer = QTimer(self)
-        self._scope_timer.setInterval(20)
-        self._scope_timer.timeout.connect(self._scope.poll)
-        self._scope_timer.start()
 
         # Prime the analysis view with the initial spinbox values.
         self._tuning._notify_params_changed()

--- a/tools/espfoc_studio/gui/scope_panel.py
+++ b/tools/espfoc_studio/gui/scope_panel.py
@@ -32,6 +32,7 @@ from PySide6.QtWidgets import (
 )
 
 from ..link import LinkReader
+from .crosshair import attach_crosshair
 
 
 # 8-entry palette tuned for legibility on a dark pyqtgraph background.
@@ -99,6 +100,9 @@ class ScopePanel(QWidget):
         self._plot.setLabel('left', "amplitude")
         self._plot.setLabel('bottom', "time", units='s')
         self._plot.showGrid(x=True, y=True, alpha=0.3)
+        self._crosshair = attach_crosshair(
+            self._plot,
+            fmt=lambda x, y: f"t = {x:.3f} s\ny = {y:+.4g}")
         root.addWidget(self._plot, 1)
 
         # Render timer keeps the Qt thread independent from the reader

--- a/tools/espfoc_studio/gui/scope_panel.py
+++ b/tools/espfoc_studio/gui/scope_panel.py
@@ -1,0 +1,70 @@
+"""Scope panel: live rolling time-series of the reference vs measurement.
+
+In --demo mode we sample the DemoFirmware's plant state directly so the
+GUI has something to show even without real scope streaming wired up.
+Real-mode will eventually plug into the scope channel of the link codec."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from typing import Callable, Deque, Optional
+
+import pyqtgraph as pg
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class ScopePanel(QWidget):
+    WINDOW_S = 2.0  # rolling window width (seconds)
+
+    def __init__(self,
+                 snapshot_source: Optional[Callable[[],
+                                                    tuple[float, float, float]]]
+                 = None) -> None:
+        super().__init__()
+        self._snapshot = snapshot_source
+        self._t_origin: Optional[float] = None
+        cap = 2000
+        self._t: Deque[float] = deque(maxlen=cap)
+        self._ref: Deque[float] = deque(maxlen=cap)
+        self._meas: Deque[float] = deque(maxlen=cap)
+
+        root = QVBoxLayout(self)
+
+        if snapshot_source is None:
+            banner = QLabel(
+                "Scope is only wired in --demo mode right now. The real "
+                "scope stream will land in a follow-up PR.")
+            banner.setWordWrap(True)
+            banner.setAlignment(Qt.AlignLeft)
+            root.addWidget(banner)
+
+        self._plot = pg.PlotWidget(title="Scope (demo plant)")
+        self._plot.setLabel('left', "current", units='A')
+        self._plot.setLabel('bottom', "time", units='s')
+        self._plot.showGrid(x=True, y=True, alpha=0.3)
+        self._plot.addLegend()
+        self._ref_curve = self._plot.plot(pen=pg.mkPen('#888', width=2,
+                                                       style=Qt.DashLine),
+                                          name="target_iq")
+        self._meas_curve = self._plot.plot(pen=pg.mkPen('#2196f3', width=2),
+                                           name="i_q (plant)")
+        root.addWidget(self._plot, 1)
+
+    def poll(self) -> None:
+        if self._snapshot is None:
+            return
+        ref, meas, now = self._snapshot()
+        if self._t_origin is None:
+            self._t_origin = now
+        self._t.append(now - self._t_origin)
+        self._ref.append(ref)
+        self._meas.append(meas)
+        # Drop samples older than WINDOW_S seconds.
+        while self._t and (self._t[-1] - self._t[0]) > self.WINDOW_S:
+            self._t.popleft()
+            self._ref.popleft()
+            self._meas.popleft()
+        self._ref_curve.setData(list(self._t), list(self._ref))
+        self._meas_curve.setData(list(self._t), list(self._meas))

--- a/tools/espfoc_studio/gui/scope_panel.py
+++ b/tools/espfoc_studio/gui/scope_panel.py
@@ -19,7 +19,7 @@ from typing import Deque, List, Optional
 
 import numpy as np
 import pyqtgraph as pg
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -48,12 +48,18 @@ _CHANNEL_COLORS = (
 
 
 class ScopePanel(QWidget):
-    """Receives SCOPE frames from a LinkReader and plots them."""
+    """Receives SCOPE frames from a LinkReader and plots them.
 
-    WINDOW_S = 2.0   # rolling window length
-    BUFFER_CAP = 4096  # max samples retained per channel
+    Frames are pushed into a bounded inbox by the reader thread; a
+    single timer on the Qt thread drains the inbox, parses all queued
+    frames in one shot and redraws the curves once. Decoupling the
+    firmware's scope rate (hundreds of Hz) from the GUI redraw rate
+    keeps the UI snappy when a current step fires a burst of samples."""
 
-    _newFrame = Signal(object)  # bytes; emitted from reader thread
+    WINDOW_S = 2.0         # rolling window length
+    BUFFER_CAP = 4096      # max samples retained per channel
+    RENDER_INTERVAL_MS = 20  # 50 FPS render cap
+    INBOX_CAP = 2048       # drop oldest when firmware outruns the GUI
 
     def __init__(self, reader: Optional[LinkReader] = None,
                  sample_period_s: float = 1e-3 * 4) -> None:
@@ -63,7 +69,8 @@ class ScopePanel(QWidget):
         super().__init__()
         self._reader = reader
         self._sample_dt = sample_period_s
-        self._lock = threading.Lock()
+        self._inbox_lock = threading.Lock()
+        self._inbox: Deque[bytes] = deque(maxlen=self.INBOX_CAP)
         self._t = 0.0  # virtual clock (sample index * dt)
         self._time_buf: Deque[float] = deque(maxlen=self.BUFFER_CAP)
         self._channel_bufs: List[Deque[float]] = []
@@ -94,9 +101,13 @@ class ScopePanel(QWidget):
         self._plot.showGrid(x=True, y=True, alpha=0.3)
         root.addWidget(self._plot, 1)
 
-        # Frames arrive on the reader's thread; cross into the Qt
-        # thread via a signal before we touch any widget.
-        self._newFrame.connect(self._on_frame_main_thread)
+        # Render timer keeps the Qt thread independent from the reader
+        # thread's frame rate. It drains the inbox and updates curves.
+        self._render_timer = QTimer(self)
+        self._render_timer.setInterval(self.RENDER_INTERVAL_MS)
+        self._render_timer.timeout.connect(self._render_tick)
+        self._render_timer.start()
+
         if reader is not None:
             reader.register_scope_callback(self._on_frame_reader_thread)
 
@@ -115,37 +126,42 @@ class ScopePanel(QWidget):
 
     def _on_frame_reader_thread(self, channel: int, seq: int,
                                 payload: bytes) -> None:
-        self._newFrame.emit(payload)
+        # Cheap hand-off to the Qt thread; no Qt call here.
+        with self._inbox_lock:
+            self._inbox.append(payload)
 
-    def _on_frame_main_thread(self, payload: bytes) -> None:
-        try:
-            line = payload.decode("ascii", errors="ignore").strip()
-        except Exception:
-            return
-        if not line:
-            return
-        try:
-            values = [float(tok) for tok in line.split(",") if tok]
-        except ValueError:
-            return
-        if not values:
-            return
-        self._ensure_channels(len(values))
-        # Fixed-rate timebase; real firmware streams at a known scope
-        # rate and the bridge preserves sample order.
-        self._t += self._sample_dt
-        self._time_buf.append(self._t)
-        for i, v in enumerate(values):
-            self._channel_bufs[i].append(v)
+    def _render_tick(self) -> None:
+        # Drain the inbox under the lock, then release so the reader
+        # thread never waits on rendering.
+        with self._inbox_lock:
+            if not self._inbox:
+                return
+            pending = list(self._inbox)
+            self._inbox.clear()
 
-        # Drop samples older than WINDOW_S so the plot stays bounded.
+        # Ingest every pending frame into the per-channel buffers.
+        for payload in pending:
+            try:
+                line = payload.decode("ascii", errors="ignore").strip()
+                values = [float(tok) for tok in line.split(",") if tok]
+            except ValueError:
+                continue
+            if not values:
+                continue
+            self._ensure_channels(len(values))
+            self._t += self._sample_dt
+            self._time_buf.append(self._t)
+            for i, v in enumerate(values):
+                self._channel_bufs[i].append(v)
+
+        # Drop samples older than WINDOW_S in one sweep.
         while self._time_buf and (self._time_buf[-1] - self._time_buf[0]
                                   > self.WINDOW_S):
             self._time_buf.popleft()
             for buf in self._channel_bufs:
                 buf.popleft()
 
-        # Refresh every curve; pyqtgraph's setData is cheap even at kHz.
+        # Single redraw per timer tick.
         t_arr = np.fromiter(self._time_buf, dtype=float,
                             count=len(self._time_buf))
         for i, curve in enumerate(self._curves):

--- a/tools/espfoc_studio/gui/scope_panel.py
+++ b/tools/espfoc_studio/gui/scope_panel.py
@@ -1,70 +1,192 @@
-"""Scope panel: live rolling time-series of the reference vs measurement.
+"""Scope panel: rolling time-series of every channel emitted by the
+firmware's esp_foc_scope.
 
-In --demo mode we sample the DemoFirmware's plant state directly so the
-GUI has something to show even without real scope streaming wired up.
-Real-mode will eventually plug into the scope channel of the link codec."""
+The firmware encodes each sample as a single CSV line on the SCOPE
+link channel (``"%f,%f,...\\n"``). This panel:
+
+* discovers the channel count from the first line (so any number of
+  scope_add_channel() calls work without UI changes);
+* draws one curve per channel with a deterministic palette;
+* provides a checkbox per channel so the user can hide / show signals
+  on the fly — useful when overlaying six SVPWM phases at once.
+"""
 
 from __future__ import annotations
 
-import time
+import threading
 from collections import deque
-from typing import Callable, Deque, Optional
+from typing import Deque, List, Optional
 
+import numpy as np
 import pyqtgraph as pg
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..link import LinkReader
+
+
+# 8-entry palette tuned for legibility on a dark pyqtgraph background.
+_CHANNEL_COLORS = (
+    "#4fc3f7",  # cyan
+    "#ffb74d",  # amber
+    "#81c784",  # green
+    "#e57373",  # red
+    "#ba68c8",  # purple
+    "#f06292",  # pink
+    "#aed581",  # lime
+    "#fff176",  # yellow
+)
 
 
 class ScopePanel(QWidget):
-    WINDOW_S = 2.0  # rolling window width (seconds)
+    """Receives SCOPE frames from a LinkReader and plots them."""
 
-    def __init__(self,
-                 snapshot_source: Optional[Callable[[],
-                                                    tuple[float, float, float]]]
-                 = None) -> None:
+    WINDOW_S = 2.0   # rolling window length
+    BUFFER_CAP = 4096  # max samples retained per channel
+
+    _newFrame = Signal(object)  # bytes; emitted from reader thread
+
+    def __init__(self, reader: Optional[LinkReader] = None,
+                 sample_period_s: float = 1e-3 * 4) -> None:
+        """sample_period_s defaults to the DemoFirmware decimation
+        (4 ms). Real firmware can override this by calling
+        set_sample_period() once its scope rate is known."""
         super().__init__()
-        self._snapshot = snapshot_source
-        self._t_origin: Optional[float] = None
-        cap = 2000
-        self._t: Deque[float] = deque(maxlen=cap)
-        self._ref: Deque[float] = deque(maxlen=cap)
-        self._meas: Deque[float] = deque(maxlen=cap)
+        self._reader = reader
+        self._sample_dt = sample_period_s
+        self._lock = threading.Lock()
+        self._t = 0.0  # virtual clock (sample index * dt)
+        self._time_buf: Deque[float] = deque(maxlen=self.BUFFER_CAP)
+        self._channel_bufs: List[Deque[float]] = []
+        self._curves: List[pg.PlotDataItem] = []
+        self._checkboxes: List[QCheckBox] = []
+        self._n_channels = 0
 
-        root = QVBoxLayout(self)
+        root = QHBoxLayout(self)
 
-        if snapshot_source is None:
-            banner = QLabel(
-                "Scope is only wired in --demo mode right now. The real "
-                "scope stream will land in a follow-up PR.")
-            banner.setWordWrap(True)
-            banner.setAlignment(Qt.AlignLeft)
-            root.addWidget(banner)
+        # Left gutter with the channel toggles.
+        gutter = QFrame()
+        gutter.setFrameShape(QFrame.NoFrame)
+        gutter.setFixedWidth(140)
+        self._gutter_layout = QVBoxLayout(gutter)
+        self._gutter_layout.setContentsMargins(4, 4, 4, 4)
+        self._gutter_layout.addWidget(QLabel("Channels"))
+        self._gutter_layout.addStretch(1)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFixedWidth(150)
+        scroll.setWidget(gutter)
+        root.addWidget(scroll)
 
-        self._plot = pg.PlotWidget(title="Scope (demo plant)")
-        self._plot.setLabel('left', "current", units='A')
+        # Plot.
+        self._plot = pg.PlotWidget(title="Scope — firmware CSV stream")
+        self._plot.setLabel('left', "amplitude")
         self._plot.setLabel('bottom', "time", units='s')
         self._plot.showGrid(x=True, y=True, alpha=0.3)
-        self._plot.addLegend()
-        self._ref_curve = self._plot.plot(pen=pg.mkPen('#888', width=2,
-                                                       style=Qt.DashLine),
-                                          name="target_iq")
-        self._meas_curve = self._plot.plot(pen=pg.mkPen('#2196f3', width=2),
-                                           name="i_q (plant)")
         root.addWidget(self._plot, 1)
 
-    def poll(self) -> None:
-        if self._snapshot is None:
+        # Frames arrive on the reader's thread; cross into the Qt
+        # thread via a signal before we touch any widget.
+        self._newFrame.connect(self._on_frame_main_thread)
+        if reader is not None:
+            reader.register_scope_callback(self._on_frame_reader_thread)
+
+    # --- Public helpers ---------------------------------------------------
+
+    def set_sample_period(self, dt_s: float) -> None:
+        """Override the estimated scope Ts (used for the x axis only)."""
+        if dt_s > 0:
+            self._sample_dt = dt_s
+
+    def attach_reader(self, reader: LinkReader) -> None:
+        self._reader = reader
+        reader.register_scope_callback(self._on_frame_reader_thread)
+
+    # --- Frame path -------------------------------------------------------
+
+    def _on_frame_reader_thread(self, channel: int, seq: int,
+                                payload: bytes) -> None:
+        self._newFrame.emit(payload)
+
+    def _on_frame_main_thread(self, payload: bytes) -> None:
+        try:
+            line = payload.decode("ascii", errors="ignore").strip()
+        except Exception:
             return
-        ref, meas, now = self._snapshot()
-        if self._t_origin is None:
-            self._t_origin = now
-        self._t.append(now - self._t_origin)
-        self._ref.append(ref)
-        self._meas.append(meas)
-        # Drop samples older than WINDOW_S seconds.
-        while self._t and (self._t[-1] - self._t[0]) > self.WINDOW_S:
-            self._t.popleft()
-            self._ref.popleft()
-            self._meas.popleft()
-        self._ref_curve.setData(list(self._t), list(self._ref))
-        self._meas_curve.setData(list(self._t), list(self._meas))
+        if not line:
+            return
+        try:
+            values = [float(tok) for tok in line.split(",") if tok]
+        except ValueError:
+            return
+        if not values:
+            return
+        self._ensure_channels(len(values))
+        # Fixed-rate timebase; real firmware streams at a known scope
+        # rate and the bridge preserves sample order.
+        self._t += self._sample_dt
+        self._time_buf.append(self._t)
+        for i, v in enumerate(values):
+            self._channel_bufs[i].append(v)
+
+        # Drop samples older than WINDOW_S so the plot stays bounded.
+        while self._time_buf and (self._time_buf[-1] - self._time_buf[0]
+                                  > self.WINDOW_S):
+            self._time_buf.popleft()
+            for buf in self._channel_bufs:
+                buf.popleft()
+
+        # Refresh every curve; pyqtgraph's setData is cheap even at kHz.
+        t_arr = np.fromiter(self._time_buf, dtype=float,
+                            count=len(self._time_buf))
+        for i, curve in enumerate(self._curves):
+            if self._checkboxes[i].isChecked():
+                y_arr = np.fromiter(self._channel_bufs[i], dtype=float,
+                                    count=len(self._channel_bufs[i]))
+                curve.setData(t_arr, y_arr)
+            else:
+                curve.setData([], [])
+
+    # --- Channel lazy-init ------------------------------------------------
+
+    def _ensure_channels(self, n: int) -> None:
+        if n <= self._n_channels:
+            return
+        # Remove the spacer we added on construction so new widgets line
+        # up cleanly.
+        spacer = self._gutter_layout.takeAt(self._gutter_layout.count() - 1)
+        for idx in range(self._n_channels, n):
+            color = _CHANNEL_COLORS[idx % len(_CHANNEL_COLORS)]
+            cb = QCheckBox(f"ch{idx}")
+            cb.setChecked(True)
+            cb.setStyleSheet(
+                f"QCheckBox {{ color: {color}; font-family: monospace; "
+                f"font-weight: bold; }}")
+            self._gutter_layout.addWidget(cb)
+            self._checkboxes.append(cb)
+            curve = self._plot.plot(
+                pen=pg.mkPen(color=QColor(color), width=2))
+            self._curves.append(curve)
+            self._channel_bufs.append(deque(maxlen=self.BUFFER_CAP))
+        # Re-add the stretch at the bottom.
+        if spacer is not None and spacer.spacerItem() is not None:
+            self._gutter_layout.addItem(spacer)
+        else:
+            self._gutter_layout.addStretch(1)
+        self._n_channels = n
+
+    # --- Backwards-compatible polling hook --------------------------------
+
+    def poll(self) -> None:
+        """Older MainWindow called this from a timer. Now that scope
+        frames are pushed directly from the reader, this is a no-op
+        kept to keep the timer wiring happy."""

--- a/tools/espfoc_studio/gui/svm_panel.py
+++ b/tools/espfoc_studio/gui/svm_panel.py
@@ -1,0 +1,219 @@
+"""Space-vector PWM hexagon view.
+
+Reads the first three channels emitted by the firmware scope (u_u,
+u_v, u_w) and renders them in the alpha/beta plane next to the six
+SVPWM base vectors. Each frame adds a new dot to a fading trail so
+you can literally watch the voltage vector rotate inside the
+hexagon during modulation.
+
+The view never touches the tuner protocol and subscribes to the
+shared LinkReader via register_scope_callback, so it coexists with
+the ScopePanel on the same scope stream.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import Deque, Optional
+
+import numpy as np
+import pyqtgraph as pg
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..link import LinkReader
+
+
+_HEX_COLOR = "#6e7681"
+_CIRCLE_COLOR = "#3a3b3f"
+_VERTEX_COLOR = "#ffcc66"
+_TRAIL_COLOR = "#4fc3f7"
+_ARROW_COLOR = "#ff7043"
+_LABEL_COLOR = "#9aa0a6"
+
+
+def _clarke(u_u: float, u_v: float, u_w: float) -> tuple[float, float]:
+    """Amplitude-invariant Clarke transform.
+
+    alpha = (2*u_u - u_v - u_w) / 3
+    beta  = (u_v - u_w) / sqrt(3)
+    """
+    inv_sqrt3 = 0.5773502691896258
+    alpha = (2.0 * u_u - u_v - u_w) / 3.0
+    beta = (u_v - u_w) * inv_sqrt3
+    return alpha, beta
+
+
+class SvmPanel(QWidget):
+    """Hexagon + live Vα/Vβ vector + fading trail."""
+
+    TRAIL_CAP = 600          # fading-trail length, samples
+    AUTOSCALE_ALPHA = 0.04   # EWMA weight for the hexagon radius
+
+    _newFrame = Signal(object)  # bytes (payload)
+
+    def __init__(self, reader: Optional[LinkReader] = None) -> None:
+        super().__init__()
+        self._reader = reader
+        self._lock = threading.Lock()
+        self._alpha_buf: Deque[float] = deque(maxlen=self.TRAIL_CAP)
+        self._beta_buf: Deque[float] = deque(maxlen=self.TRAIL_CAP)
+        self._hex_radius = 1.0   # dynamically tracked
+        self._last_ab: tuple[float, float] = (0.0, 0.0)
+
+        root = QVBoxLayout(self)
+        info = QLabel(
+            "Space-vector PWM hexagon — reads channels 0/1/2 as "
+            "u_u / u_v / u_w. The active vector (orange) and its fading "
+            "trail (cyan) are computed on the fly from those three "
+            "phases; the hexagon auto-scales to the observed modulation.")
+        info.setWordWrap(True)
+        info.setAlignment(Qt.AlignLeft)
+        root.addWidget(info)
+
+        plot_row = QHBoxLayout()
+        root.addLayout(plot_row, 1)
+
+        self._plot = pg.PlotWidget(title="SVPWM voltage vector")
+        self._plot.setAspectLocked(True)
+        self._plot.setLabel('left', "β", units='V')
+        self._plot.setLabel('bottom', "α", units='V')
+        self._plot.showGrid(x=True, y=True, alpha=0.15)
+
+        # Static layer: hexagon outline + inscribed circle + base vectors.
+        self._hex_curve = self._plot.plot(
+            pen=pg.mkPen(QColor(_HEX_COLOR), width=2))
+        self._circle_curve = self._plot.plot(
+            pen=pg.mkPen(QColor(_CIRCLE_COLOR), width=1,
+                         style=Qt.DashLine))
+        self._vertex_scatter = pg.ScatterPlotItem(
+            size=10, symbol='o',
+            pen=pg.mkPen(QColor(_VERTEX_COLOR)),
+            brush=pg.mkBrush(QColor(_VERTEX_COLOR)))
+        self._plot.addItem(self._vertex_scatter)
+
+        # Dynamic layer: fading trail + current vector arrow.
+        self._trail_curve = self._plot.plot(
+            pen=pg.mkPen(QColor(_TRAIL_COLOR), width=1))
+        self._arrow_curve = self._plot.plot(
+            pen=pg.mkPen(QColor(_ARROW_COLOR), width=3))
+        self._head_scatter = pg.ScatterPlotItem(
+            size=14, symbol='o',
+            pen=pg.mkPen(QColor(_ARROW_COLOR), width=2),
+            brush=pg.mkBrush(QColor(_ARROW_COLOR)))
+        self._plot.addItem(self._head_scatter)
+
+        self._redraw_hexagon()
+        plot_row.addWidget(self._plot, 1)
+
+        # Live numeric readout on the side.
+        side = QVBoxLayout()
+        side.setContentsMargins(6, 6, 6, 6)
+        side.setSpacing(4)
+        self._alpha_label = QLabel("α = 0.000 V")
+        self._beta_label = QLabel("β = 0.000 V")
+        self._mag_label = QLabel("|V| = 0.000 V")
+        self._sector_label = QLabel("sector: -")
+        for lbl in (self._alpha_label, self._beta_label,
+                    self._mag_label, self._sector_label):
+            lbl.setStyleSheet("font-family: monospace; color: %s;"
+                              % _LABEL_COLOR)
+            side.addWidget(lbl)
+        side.addStretch(1)
+        plot_row.addLayout(side, 0)
+
+        self._newFrame.connect(self._on_frame_main_thread)
+        if reader is not None:
+            reader.register_scope_callback(self._on_frame_reader_thread)
+
+    # --- Subscription helpers --------------------------------------------
+
+    def attach_reader(self, reader: LinkReader) -> None:
+        self._reader = reader
+        reader.register_scope_callback(self._on_frame_reader_thread)
+
+    def detach(self) -> None:
+        if self._reader is not None:
+            self._reader.unregister_scope_callback(
+                self._on_frame_reader_thread)
+            self._reader = None
+
+    # --- Frame path -------------------------------------------------------
+
+    def _on_frame_reader_thread(self, channel: int, seq: int,
+                                payload: bytes) -> None:
+        self._newFrame.emit(payload)
+
+    def _on_frame_main_thread(self, payload: bytes) -> None:
+        try:
+            tokens = payload.decode("ascii", errors="ignore").strip().split(",")
+            vals = [float(t) for t in tokens[:3] if t]
+        except ValueError:
+            return
+        if len(vals) < 3:
+            return
+        u_u, u_v, u_w = vals[0], vals[1], vals[2]
+        a, b = _clarke(u_u, u_v, u_w)
+        self._alpha_buf.append(a)
+        self._beta_buf.append(b)
+        self._last_ab = (a, b)
+
+        mag = (a * a + b * b) ** 0.5
+        # EWMA on hexagon radius to avoid jittery rescaling. Add 20 %
+        # headroom so vertices stay outside the trail.
+        target = max(mag * 1.2, 1e-6)
+        self._hex_radius = ((1.0 - self.AUTOSCALE_ALPHA) * self._hex_radius
+                            + self.AUTOSCALE_ALPHA * target)
+        # If the trail already exceeds the current hexagon, snap to fit.
+        if target > self._hex_radius:
+            self._hex_radius = target
+
+        self._redraw_hexagon()
+        self._redraw_trail_and_arrow(a, b, mag)
+
+    # --- Static geometry --------------------------------------------------
+
+    def _redraw_hexagon(self) -> None:
+        R = self._hex_radius
+        angles = np.arange(7) * (np.pi / 3.0)  # close the polygon
+        hx = R * np.cos(angles)
+        hy = R * np.sin(angles)
+        self._hex_curve.setData(hx, hy)
+        theta = np.linspace(0, 2.0 * np.pi, 181)
+        rc = R * (np.sqrt(3.0) / 2.0)
+        self._circle_curve.setData(rc * np.cos(theta), rc * np.sin(theta))
+        vx = R * np.cos(angles[:-1])
+        vy = R * np.sin(angles[:-1])
+        self._vertex_scatter.setData(pos=np.column_stack((vx, vy)))
+
+    def _redraw_trail_and_arrow(self, a: float, b: float, mag: float) -> None:
+        t_a = np.fromiter(self._alpha_buf, dtype=float,
+                          count=len(self._alpha_buf))
+        t_b = np.fromiter(self._beta_buf, dtype=float,
+                          count=len(self._beta_buf))
+        self._trail_curve.setData(t_a, t_b)
+        self._arrow_curve.setData([0.0, a], [0.0, b])
+        self._head_scatter.setData(pos=np.array([[a, b]]))
+        self._alpha_label.setText(f"α = {a:+8.3f} V")
+        self._beta_label.setText(f"β = {b:+8.3f} V")
+        self._mag_label.setText(f"|V| = {mag:8.3f} V")
+        # Sector 1..6 based on angle (0..2π).
+        if mag < 1e-6:
+            sector_text = "sector: -"
+        else:
+            import math
+            angle = math.atan2(b, a)
+            if angle < 0:
+                angle += 2.0 * math.pi
+            sector = int(angle // (math.pi / 3.0)) + 1
+            if sector > 6:
+                sector = 6
+            sector_text = f"sector: {sector}"
+        self._sector_label.setText(sector_text)

--- a/tools/espfoc_studio/gui/svm_panel.py
+++ b/tools/espfoc_studio/gui/svm_panel.py
@@ -1,18 +1,19 @@
 """Space-vector PWM hexagon view.
 
-Reads the first three channels emitted by the firmware scope
-(u_u / u_v / u_w) and draws:
+Reads channels 0/1/2 (u_u, u_v, u_w) from the firmware scope stream
+and shows:
 
-* the active voltage vector (Vα, Vβ) as it moves inside the SVPWM
-  hexagon, with a fading trail of recent positions;
-* the three-phase time-series below the hexagon so you can correlate
-  the waveform shape with the rotating vector.
+* three fixed phase axes (A/B/C at 0°/120°/240°) with a colored
+  "phase projection" vector each — their length is the instantaneous
+  u_u / u_v / u_w, so you see the three components animate along
+  their axes as the electrical angle sweeps;
+* the resultant V_αβ vector (Clarke sum of the three phases) with a
+  fading trail so the rotation on the hexagon is visible at a glance;
+* the three-phase time-series underneath, colored identically to the
+  scope tab's channels 0/1/2.
 
-Like ScopePanel, this view buffers frames in an inbox on the reader
-thread and renders them on a QTimer so the GUI stays responsive even
-when the firmware emits a burst of samples after a current step. The
-SVM redraw is intentionally slower than the scope's (smooth enough
-for the eye, light on CPU when the motor is running).
+Rendering is buffered on the reader side and flushed at 20 FPS so
+scope bursts after a current step do not stall the Qt loop.
 """
 
 from __future__ import annotations
@@ -88,16 +89,6 @@ class SvmPanel(QWidget):
         self._last_ab: tuple[float, float] = (0.0, 0.0)
 
         root = QVBoxLayout(self)
-        info = QLabel(
-            "Space-vector PWM hexagon — reads channels 0/1/2 as "
-            "u_u / u_v / u_w. The active vector (orange) and its fading "
-            "trail (cyan) are computed on the fly from those three "
-            "phases; the time-series below shows the waveform feeding "
-            "the hexagon. Refresh rate is deliberately lower than the "
-            "scope so the Qt event loop stays snappy during bursts.")
-        info.setWordWrap(True)
-        info.setAlignment(Qt.AlignLeft)
-        root.addWidget(info)
 
         # --- Top half: hexagon + readout column --------------------------
         top_row = QHBoxLayout()
@@ -119,6 +110,20 @@ class SvmPanel(QWidget):
             pen=pg.mkPen(QColor(_VERTEX_COLOR)),
             brush=pg.mkBrush(QColor(_VERTEX_COLOR)))
         self._plot.addItem(self._vertex_scatter)
+
+        # Three static phase axes (A at 0°, B at 120°, C at 240°) — the
+        # "rails" along which the instantaneous phase values project.
+        self._phase_axis_curves = tuple(
+            self._plot.plot(pen=pg.mkPen(QColor(c), width=1,
+                                          style=Qt.DashLine))
+            for c in _PHASE_COLORS)
+        # Dynamic phase projection vectors: length = u_u / u_v / u_w,
+        # direction = phase-axis unit vector. Drawn under the resultant
+        # so the orange arrow stays on top.
+        self._phase_vec_curves = tuple(
+            self._plot.plot(pen=pg.mkPen(QColor(c), width=2))
+            for c in _PHASE_COLORS)
+
         self._trail_curve = self._plot.plot(
             pen=pg.mkPen(QColor(_TRAIL_COLOR), width=1))
         self._arrow_curve = self._plot.plot(
@@ -233,7 +238,18 @@ class SvmPanel(QWidget):
             self._hex_radius = target
         self._redraw_hexagon()
 
-        # Trail + arrow in the hexagon.
+        # Phase projection arrows (u_u along A axis, u_v along B, u_w
+        # along C). The three arrow tips sum (scaled by 2/3) to the
+        # resultant V — a live Clarke transform in picture form.
+        if self._uu_buf and self._uv_buf and self._uw_buf:
+            phases = (self._uu_buf[-1],
+                      self._uv_buf[-1],
+                      self._uw_buf[-1])
+            for curve, (dx, dy), mag in zip(self._phase_vec_curves,
+                                            self._PHASE_DIRS, phases):
+                curve.setData([0.0, mag * dx], [0.0, mag * dy])
+
+        # Trail + resultant arrow (drawn on top).
         t_a = np.fromiter(self._alpha_buf, dtype=float,
                           count=len(self._alpha_buf))
         t_b = np.fromiter(self._beta_buf, dtype=float,
@@ -273,6 +289,15 @@ class SvmPanel(QWidget):
 
     # --- Static geometry --------------------------------------------------
 
+    # Phase-axis unit vectors (A=0°, B=120°, C=240°). Dashed rails in the
+    # static layer; phase projection arrows in the dynamic layer sit on
+    # these directions with length = instantaneous u_u / u_v / u_w.
+    _PHASE_DIRS = (
+        (1.0, 0.0),
+        (-0.5, 0.86602540378),       # cos(120°), sin(120°)
+        (-0.5, -0.86602540378),      # cos(240°), sin(240°)
+    )
+
     def _redraw_hexagon(self) -> None:
         R = self._hex_radius
         angles = np.arange(7) * (np.pi / 3.0)  # close the polygon
@@ -285,3 +310,7 @@ class SvmPanel(QWidget):
         vx = R * np.cos(angles[:-1])
         vy = R * np.sin(angles[:-1])
         self._vertex_scatter.setData(pos=np.column_stack((vx, vy)))
+        # Phase axes span -R .. +R along each direction; the negative
+        # half shows projection when a phase goes below zero.
+        for curve, (dx, dy) in zip(self._phase_axis_curves, self._PHASE_DIRS):
+            curve.setData([-R * dx, R * dx], [-R * dy, R * dy])

--- a/tools/espfoc_studio/gui/svm_panel.py
+++ b/tools/espfoc_studio/gui/svm_panel.py
@@ -1,14 +1,18 @@
 """Space-vector PWM hexagon view.
 
-Reads the first three channels emitted by the firmware scope (u_u,
-u_v, u_w) and renders them in the alpha/beta plane next to the six
-SVPWM base vectors. Each frame adds a new dot to a fading trail so
-you can literally watch the voltage vector rotate inside the
-hexagon during modulation.
+Reads the first three channels emitted by the firmware scope
+(u_u / u_v / u_w) and draws:
 
-The view never touches the tuner protocol and subscribes to the
-shared LinkReader via register_scope_callback, so it coexists with
-the ScopePanel on the same scope stream.
+* the active voltage vector (Vα, Vβ) as it moves inside the SVPWM
+  hexagon, with a fading trail of recent positions;
+* the three-phase time-series below the hexagon so you can correlate
+  the waveform shape with the rotating vector.
+
+Like ScopePanel, this view buffers frames in an inbox on the reader
+thread and renders them on a QTimer so the GUI stays responsive even
+when the firmware emits a burst of samples after a current step. The
+SVM redraw is intentionally slower than the scope's (smooth enough
+for the eye, light on CPU when the motor is running).
 """
 
 from __future__ import annotations
@@ -19,7 +23,7 @@ from typing import Deque, Optional
 
 import numpy as np
 import pyqtgraph as pg
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -37,6 +41,9 @@ _VERTEX_COLOR = "#ffcc66"
 _TRAIL_COLOR = "#4fc3f7"
 _ARROW_COLOR = "#ff7043"
 _LABEL_COLOR = "#9aa0a6"
+# Keep these in sync with ScopePanel's first three entries so a phase
+# colour in the SVM view matches its counterpart in the scope tab.
+_PHASE_COLORS = ("#4fc3f7", "#ffb74d", "#81c784")
 
 
 def _clarke(u_u: float, u_v: float, u_w: float) -> tuple[float, float]:
@@ -52,20 +59,32 @@ def _clarke(u_u: float, u_v: float, u_w: float) -> tuple[float, float]:
 
 
 class SvmPanel(QWidget):
-    """Hexagon + live Vα/Vβ vector + fading trail."""
+    """Hexagon + live Vα/Vβ vector + fading trail + three-phase plot."""
 
-    TRAIL_CAP = 600          # fading-trail length, samples
-    AUTOSCALE_ALPHA = 0.04   # EWMA weight for the hexagon radius
+    TRAIL_CAP = 600           # hexagon trail length, samples
+    WAVEFORM_CAP = 1024       # waveform history, samples
+    WAVEFORM_WINDOW_S = 0.5   # visible span in the three-phase plot
+    AUTOSCALE_ALPHA = 0.04    # EWMA weight for hexagon radius
+    RENDER_INTERVAL_MS = 50   # 20 FPS — smooth but lighter than the scope
+    INBOX_CAP = 512           # bound the producer/consumer queue
 
-    _newFrame = Signal(object)  # bytes (payload)
-
-    def __init__(self, reader: Optional[LinkReader] = None) -> None:
+    def __init__(self, reader: Optional[LinkReader] = None,
+                 sample_period_s: float = 1e-3 * 4) -> None:
         super().__init__()
         self._reader = reader
-        self._lock = threading.Lock()
+        self._sample_dt = sample_period_s
+        self._inbox_lock = threading.Lock()
+        self._inbox: Deque[bytes] = deque(maxlen=self.INBOX_CAP)
+
         self._alpha_buf: Deque[float] = deque(maxlen=self.TRAIL_CAP)
         self._beta_buf: Deque[float] = deque(maxlen=self.TRAIL_CAP)
-        self._hex_radius = 1.0   # dynamically tracked
+        self._time_buf: Deque[float] = deque(maxlen=self.WAVEFORM_CAP)
+        self._uu_buf: Deque[float] = deque(maxlen=self.WAVEFORM_CAP)
+        self._uv_buf: Deque[float] = deque(maxlen=self.WAVEFORM_CAP)
+        self._uw_buf: Deque[float] = deque(maxlen=self.WAVEFORM_CAP)
+        self._t = 0.0
+
+        self._hex_radius = 1.0
         self._last_ab: tuple[float, float] = (0.0, 0.0)
 
         root = QVBoxLayout(self)
@@ -73,13 +92,16 @@ class SvmPanel(QWidget):
             "Space-vector PWM hexagon — reads channels 0/1/2 as "
             "u_u / u_v / u_w. The active vector (orange) and its fading "
             "trail (cyan) are computed on the fly from those three "
-            "phases; the hexagon auto-scales to the observed modulation.")
+            "phases; the time-series below shows the waveform feeding "
+            "the hexagon. Refresh rate is deliberately lower than the "
+            "scope so the Qt event loop stays snappy during bursts.")
         info.setWordWrap(True)
         info.setAlignment(Qt.AlignLeft)
         root.addWidget(info)
 
-        plot_row = QHBoxLayout()
-        root.addLayout(plot_row, 1)
+        # --- Top half: hexagon + readout column --------------------------
+        top_row = QHBoxLayout()
+        root.addLayout(top_row, 2)
 
         self._plot = pg.PlotWidget(title="SVPWM voltage vector")
         self._plot.setAspectLocked(True)
@@ -87,7 +109,6 @@ class SvmPanel(QWidget):
         self._plot.setLabel('bottom', "α", units='V')
         self._plot.showGrid(x=True, y=True, alpha=0.15)
 
-        # Static layer: hexagon outline + inscribed circle + base vectors.
         self._hex_curve = self._plot.plot(
             pen=pg.mkPen(QColor(_HEX_COLOR), width=2))
         self._circle_curve = self._plot.plot(
@@ -98,8 +119,6 @@ class SvmPanel(QWidget):
             pen=pg.mkPen(QColor(_VERTEX_COLOR)),
             brush=pg.mkBrush(QColor(_VERTEX_COLOR)))
         self._plot.addItem(self._vertex_scatter)
-
-        # Dynamic layer: fading trail + current vector arrow.
         self._trail_curve = self._plot.plot(
             pen=pg.mkPen(QColor(_TRAIL_COLOR), width=1))
         self._arrow_curve = self._plot.plot(
@@ -109,11 +128,9 @@ class SvmPanel(QWidget):
             pen=pg.mkPen(QColor(_ARROW_COLOR), width=2),
             brush=pg.mkBrush(QColor(_ARROW_COLOR)))
         self._plot.addItem(self._head_scatter)
-
         self._redraw_hexagon()
-        plot_row.addWidget(self._plot, 1)
+        top_row.addWidget(self._plot, 1)
 
-        # Live numeric readout on the side.
         side = QVBoxLayout()
         side.setContentsMargins(6, 6, 6, 6)
         side.setSpacing(4)
@@ -127,9 +144,28 @@ class SvmPanel(QWidget):
                               % _LABEL_COLOR)
             side.addWidget(lbl)
         side.addStretch(1)
-        plot_row.addLayout(side, 0)
+        top_row.addLayout(side, 0)
 
-        self._newFrame.connect(self._on_frame_main_thread)
+        # --- Bottom half: three-phase waveform ---------------------------
+        self._wave_plot = pg.PlotWidget(title="Three-phase output")
+        self._wave_plot.setLabel('left', "voltage", units='V')
+        self._wave_plot.setLabel('bottom', "time", units='s')
+        self._wave_plot.showGrid(x=True, y=True, alpha=0.2)
+        self._wave_plot.addLegend()
+        self._uu_curve = self._wave_plot.plot(
+            pen=pg.mkPen(QColor(_PHASE_COLORS[0]), width=2), name="u_u (ch0)")
+        self._uv_curve = self._wave_plot.plot(
+            pen=pg.mkPen(QColor(_PHASE_COLORS[1]), width=2), name="u_v (ch1)")
+        self._uw_curve = self._wave_plot.plot(
+            pen=pg.mkPen(QColor(_PHASE_COLORS[2]), width=2), name="u_w (ch2)")
+        root.addWidget(self._wave_plot, 1)
+
+        # --- Render timer ------------------------------------------------
+        self._render_timer = QTimer(self)
+        self._render_timer.setInterval(self.RENDER_INTERVAL_MS)
+        self._render_timer.timeout.connect(self._render_tick)
+        self._render_timer.start()
+
         if reader is not None:
             reader.register_scope_callback(self._on_frame_reader_thread)
 
@@ -149,34 +185,91 @@ class SvmPanel(QWidget):
 
     def _on_frame_reader_thread(self, channel: int, seq: int,
                                 payload: bytes) -> None:
-        self._newFrame.emit(payload)
+        with self._inbox_lock:
+            self._inbox.append(payload)
 
-    def _on_frame_main_thread(self, payload: bytes) -> None:
-        try:
-            tokens = payload.decode("ascii", errors="ignore").strip().split(",")
-            vals = [float(t) for t in tokens[:3] if t]
-        except ValueError:
-            return
-        if len(vals) < 3:
-            return
-        u_u, u_v, u_w = vals[0], vals[1], vals[2]
-        a, b = _clarke(u_u, u_v, u_w)
-        self._alpha_buf.append(a)
-        self._beta_buf.append(b)
-        self._last_ab = (a, b)
+    def _render_tick(self) -> None:
+        with self._inbox_lock:
+            if not self._inbox:
+                return
+            pending = list(self._inbox)
+            self._inbox.clear()
 
+        for payload in pending:
+            try:
+                tokens = payload.decode("ascii",
+                                       errors="ignore").strip().split(",")
+                vals = [float(t) for t in tokens[:3] if t]
+            except ValueError:
+                continue
+            if len(vals) < 3:
+                continue
+            u_u, u_v, u_w = vals[0], vals[1], vals[2]
+            a, b = _clarke(u_u, u_v, u_w)
+            self._alpha_buf.append(a)
+            self._beta_buf.append(b)
+            self._t += self._sample_dt
+            self._time_buf.append(self._t)
+            self._uu_buf.append(u_u)
+            self._uv_buf.append(u_v)
+            self._uw_buf.append(u_w)
+            self._last_ab = (a, b)
+
+        # Trim waveform window.
+        while self._time_buf and (self._time_buf[-1] - self._time_buf[0]
+                                  > self.WAVEFORM_WINDOW_S):
+            self._time_buf.popleft()
+            self._uu_buf.popleft()
+            self._uv_buf.popleft()
+            self._uw_buf.popleft()
+
+        # Auto-scale the hexagon against the most recent magnitude.
+        a, b = self._last_ab
         mag = (a * a + b * b) ** 0.5
-        # EWMA on hexagon radius to avoid jittery rescaling. Add 20 %
-        # headroom so vertices stay outside the trail.
         target = max(mag * 1.2, 1e-6)
         self._hex_radius = ((1.0 - self.AUTOSCALE_ALPHA) * self._hex_radius
                             + self.AUTOSCALE_ALPHA * target)
-        # If the trail already exceeds the current hexagon, snap to fit.
         if target > self._hex_radius:
             self._hex_radius = target
-
         self._redraw_hexagon()
-        self._redraw_trail_and_arrow(a, b, mag)
+
+        # Trail + arrow in the hexagon.
+        t_a = np.fromiter(self._alpha_buf, dtype=float,
+                          count=len(self._alpha_buf))
+        t_b = np.fromiter(self._beta_buf, dtype=float,
+                          count=len(self._beta_buf))
+        self._trail_curve.setData(t_a, t_b)
+        self._arrow_curve.setData([0.0, a], [0.0, b])
+        self._head_scatter.setData(pos=np.array([[a, b]]))
+
+        # Three-phase waveform.
+        t_arr = np.fromiter(self._time_buf, dtype=float,
+                            count=len(self._time_buf))
+        self._uu_curve.setData(t_arr,
+                               np.fromiter(self._uu_buf, dtype=float,
+                                           count=len(self._uu_buf)))
+        self._uv_curve.setData(t_arr,
+                               np.fromiter(self._uv_buf, dtype=float,
+                                           count=len(self._uv_buf)))
+        self._uw_curve.setData(t_arr,
+                               np.fromiter(self._uw_buf, dtype=float,
+                                           count=len(self._uw_buf)))
+
+        # Readout labels.
+        self._alpha_label.setText(f"α = {a:+8.3f} V")
+        self._beta_label.setText(f"β = {b:+8.3f} V")
+        self._mag_label.setText(f"|V| = {mag:8.3f} V")
+        if mag < 1e-6:
+            self._sector_label.setText("sector: -")
+        else:
+            import math
+            ang = math.atan2(b, a)
+            if ang < 0:
+                ang += 2.0 * math.pi
+            sec = int(ang // (math.pi / 3.0)) + 1
+            if sec > 6:
+                sec = 6
+            self._sector_label.setText(f"sector: {sec}")
 
     # --- Static geometry --------------------------------------------------
 
@@ -192,28 +285,3 @@ class SvmPanel(QWidget):
         vx = R * np.cos(angles[:-1])
         vy = R * np.sin(angles[:-1])
         self._vertex_scatter.setData(pos=np.column_stack((vx, vy)))
-
-    def _redraw_trail_and_arrow(self, a: float, b: float, mag: float) -> None:
-        t_a = np.fromiter(self._alpha_buf, dtype=float,
-                          count=len(self._alpha_buf))
-        t_b = np.fromiter(self._beta_buf, dtype=float,
-                          count=len(self._beta_buf))
-        self._trail_curve.setData(t_a, t_b)
-        self._arrow_curve.setData([0.0, a], [0.0, b])
-        self._head_scatter.setData(pos=np.array([[a, b]]))
-        self._alpha_label.setText(f"α = {a:+8.3f} V")
-        self._beta_label.setText(f"β = {b:+8.3f} V")
-        self._mag_label.setText(f"|V| = {mag:8.3f} V")
-        # Sector 1..6 based on angle (0..2π).
-        if mag < 1e-6:
-            sector_text = "sector: -"
-        else:
-            import math
-            angle = math.atan2(b, a)
-            if angle < 0:
-                angle += 2.0 * math.pi
-            sector = int(angle // (math.pi / 3.0)) + 1
-            if sector > 6:
-                sector = 6
-            sector_text = f"sector: {sector}"
-        self._sector_label.setText(sector_text)

--- a/tools/espfoc_studio/gui/svm_panel.py
+++ b/tools/espfoc_studio/gui/svm_panel.py
@@ -34,6 +34,7 @@ from PySide6.QtWidgets import (
 )
 
 from ..link import LinkReader
+from .crosshair import attach_crosshair
 
 
 _HEX_COLOR = "#6e7681"
@@ -99,6 +100,9 @@ class SvmPanel(QWidget):
         self._plot.setLabel('left', "β", units='V')
         self._plot.setLabel('bottom', "α", units='V')
         self._plot.showGrid(x=True, y=True, alpha=0.15)
+        self._hex_crosshair = attach_crosshair(
+            self._plot,
+            fmt=lambda x, y: f"α = {x:+.3f}\nβ = {y:+.3f}")
 
         self._hex_curve = self._plot.plot(
             pen=pg.mkPen(QColor(_HEX_COLOR), width=2))
@@ -113,16 +117,28 @@ class SvmPanel(QWidget):
 
         # Three static phase axes (A at 0°, B at 120°, C at 240°) — the
         # "rails" along which the instantaneous phase values project.
+        # Drawn in a neutral dim colour so they guide the eye without
+        # competing with the bright phase-projection vectors that sit
+        # on top of them.
         self._phase_axis_curves = tuple(
-            self._plot.plot(pen=pg.mkPen(QColor(c), width=1,
+            self._plot.plot(pen=pg.mkPen(QColor("#555759"), width=1,
                                           style=Qt.DashLine))
-            for c in _PHASE_COLORS)
+            for _ in _PHASE_COLORS)
         # Dynamic phase projection vectors: length = u_u / u_v / u_w,
-        # direction = phase-axis unit vector. Drawn under the resultant
-        # so the orange arrow stays on top.
+        # direction = phase-axis unit vector. These carry the per-phase
+        # colour so you can tell ch0/ch1/ch2 apart at a glance.
         self._phase_vec_curves = tuple(
-            self._plot.plot(pen=pg.mkPen(QColor(c), width=2))
+            self._plot.plot(pen=pg.mkPen(QColor(c), width=3))
             for c in _PHASE_COLORS)
+        self._phase_vec_tips = pg.ScatterPlotItem(
+            size=9, symbol='o', pen=None)
+        # Prime with three points at origin so pyqtgraph accepts the
+        # per-point brush list (3 items) — positions are updated every
+        # render tick.
+        self._phase_vec_tips.setData(
+            pos=np.zeros((3, 2)),
+            brush=[pg.mkBrush(QColor(c)) for c in _PHASE_COLORS])
+        self._plot.addItem(self._phase_vec_tips)
 
         self._trail_curve = self._plot.plot(
             pen=pg.mkPen(QColor(_TRAIL_COLOR), width=1))
@@ -157,6 +173,9 @@ class SvmPanel(QWidget):
         self._wave_plot.setLabel('bottom', "time", units='s')
         self._wave_plot.showGrid(x=True, y=True, alpha=0.2)
         self._wave_plot.addLegend()
+        self._wave_crosshair = attach_crosshair(
+            self._wave_plot,
+            fmt=lambda x, y: f"t = {x:.4f} s\nu = {y:+.3f} V")
         self._uu_curve = self._wave_plot.plot(
             pen=pg.mkPen(QColor(_PHASE_COLORS[0]), width=2), name="u_u (ch0)")
         self._uv_curve = self._wave_plot.plot(
@@ -245,9 +264,13 @@ class SvmPanel(QWidget):
             phases = (self._uu_buf[-1],
                       self._uv_buf[-1],
                       self._uw_buf[-1])
+            tip_positions = []
             for curve, (dx, dy), mag in zip(self._phase_vec_curves,
                                             self._PHASE_DIRS, phases):
-                curve.setData([0.0, mag * dx], [0.0, mag * dy])
+                tip = (mag * dx, mag * dy)
+                curve.setData([0.0, tip[0]], [0.0, tip[1]])
+                tip_positions.append(tip)
+            self._phase_vec_tips.setData(pos=np.array(tip_positions))
 
         # Trail + resultant arrow (drawn on top).
         t_a = np.fromiter(self._alpha_buf, dtype=float,

--- a/tools/espfoc_studio/gui/theme.py
+++ b/tools/espfoc_studio/gui/theme.py
@@ -1,0 +1,117 @@
+"""Dark theme applied before any window is shown.
+
+Uses Qt's Fusion style with a handcrafted palette so it looks the same
+on every OS and does not require an extra dependency. pyqtgraph gets
+its own dark background via setConfigOption; the two conventions need
+to agree or the plots look washed out against the panel chrome.
+"""
+
+from __future__ import annotations
+
+import pyqtgraph as pg
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtWidgets import QApplication
+
+
+_BG = "#1e1f22"        # window background
+_BG_ALT = "#26272b"    # group box / card
+_FG = "#e6e6e6"        # primary text
+_DIM = "#9aa0a6"       # secondary text
+_ACCENT = "#4fc3f7"    # highlight (links, selection)
+_BORDER = "#3a3b3f"
+_ERROR = "#ef5350"
+
+
+def apply_dark_theme(app: QApplication) -> None:
+    app.setStyle("Fusion")
+
+    pal = QPalette()
+    pal.setColor(QPalette.Window, QColor(_BG))
+    pal.setColor(QPalette.WindowText, QColor(_FG))
+    pal.setColor(QPalette.Base, QColor(_BG_ALT))
+    pal.setColor(QPalette.AlternateBase, QColor(_BG))
+    pal.setColor(QPalette.Text, QColor(_FG))
+    pal.setColor(QPalette.Button, QColor(_BG_ALT))
+    pal.setColor(QPalette.ButtonText, QColor(_FG))
+    pal.setColor(QPalette.ToolTipBase, QColor(_BG))
+    pal.setColor(QPalette.ToolTipText, QColor(_FG))
+    pal.setColor(QPalette.PlaceholderText, QColor(_DIM))
+    pal.setColor(QPalette.Highlight, QColor(_ACCENT))
+    pal.setColor(QPalette.HighlightedText, QColor("#0b0c0d"))
+    pal.setColor(QPalette.Link, QColor(_ACCENT))
+    pal.setColor(QPalette.BrightText, QColor(_ERROR))
+    pal.setColor(QPalette.Disabled, QPalette.Text, QColor(_DIM))
+    pal.setColor(QPalette.Disabled, QPalette.ButtonText, QColor(_DIM))
+    pal.setColor(QPalette.Disabled, QPalette.WindowText, QColor(_DIM))
+    app.setPalette(pal)
+
+    # Extra polish on top of Fusion: softer group-box borders, denser
+    # header typography. Kept short so the theme ships dep-free.
+    app.setStyleSheet(f"""
+        QMainWindow, QWidget {{
+            background-color: {_BG};
+            color: {_FG};
+        }}
+        QGroupBox {{
+            border: 1px solid {_BORDER};
+            border-radius: 6px;
+            margin-top: 12px;
+            padding: 6px;
+            background-color: {_BG_ALT};
+        }}
+        QGroupBox::title {{
+            subcontrol-origin: margin;
+            subcontrol-position: top left;
+            left: 8px;
+            padding: 0 4px;
+            color: {_DIM};
+            font-size: 11px;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+        }}
+        QLabel, QCheckBox, QRadioButton {{
+            color: {_FG};
+        }}
+        QLineEdit, QDoubleSpinBox, QSpinBox, QComboBox {{
+            background-color: #2b2c30;
+            border: 1px solid {_BORDER};
+            border-radius: 4px;
+            padding: 3px 6px;
+            selection-background-color: {_ACCENT};
+            selection-color: #0b0c0d;
+        }}
+        QPushButton {{
+            background-color: #303236;
+            border: 1px solid {_BORDER};
+            border-radius: 4px;
+            padding: 6px 12px;
+        }}
+        QPushButton:hover {{ background-color: #3a3c41; }}
+        QPushButton:pressed {{ background-color: #2a2c30; }}
+        QTabWidget::pane {{ border: 1px solid {_BORDER}; border-radius: 4px; }}
+        QTabBar::tab {{
+            background: {_BG};
+            color: {_DIM};
+            padding: 6px 12px;
+            border: 1px solid transparent;
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+        }}
+        QTabBar::tab:selected {{
+            background: {_BG_ALT};
+            color: {_FG};
+            border: 1px solid {_BORDER};
+            border-bottom-color: {_BG_ALT};
+        }}
+        QSplitter::handle {{ background: {_BORDER}; }}
+        QScrollArea, QScrollArea > QWidget > QWidget {{
+            background-color: {_BG};
+        }}
+    """)
+
+    # Align pyqtgraph's own colours with the palette so the plot canvas
+    # blends with the panel around it.
+    pg.setConfigOption("background", _BG_ALT)
+    pg.setConfigOption("foreground", _FG)
+    pg.setConfigOption("antialias", True)

--- a/tools/espfoc_studio/gui/tuning_panel.py
+++ b/tools/espfoc_studio/gui/tuning_panel.py
@@ -20,14 +20,25 @@ from PySide6.QtWidgets import (
 from ..protocol import AxisStateFlag, TunerClient, TunerError
 
 
-def _spin(maximum: float = 10000.0, minimum: float = -10000.0,
-          decimals: int = 4, value: float = 0.0,
-          step: float = 0.1) -> QDoubleSpinBox:
+def _spin(minimum: float, maximum: float,
+          decimals: int, value: float,
+          step: float = 0.1,
+          suffix: str = "") -> QDoubleSpinBox:
+    """Convenience wrapper matching Qt's (min, max) ordering and with an
+    optional unit suffix. Type-in is always allowed — the step value
+    only controls the ± buttons / scroll wheel."""
+    if minimum > maximum:
+        minimum, maximum = maximum, minimum
     box = QDoubleSpinBox()
     box.setRange(minimum, maximum)
     box.setDecimals(decimals)
     box.setSingleStep(step)
     box.setValue(value)
+    if suffix:
+        box.setSuffix(suffix)
+    # Keep the spinner buttons; make the field wide enough so long
+    # suffixes like " Ω" do not visually collide with the number.
+    box.setMinimumWidth(140)
     return box
 
 
@@ -74,9 +85,10 @@ class TuningPanel(QWidget):
         # --- Manual gain editor ---
         manual = QGroupBox("Manual gain override")
         mform = QFormLayout(manual)
-        self._kp_spin = _spin(0, 500, 4, 1.46)
-        self._ki_spin = _spin(0, 1_000_000, 2, 659.17, 10.0)
-        self._lim_spin = _spin(0, 200, 3, 12.0)
+        self._kp_spin = _spin(0.0, 500.0, 4, 1.46, step=0.01, suffix=" V/A")
+        self._ki_spin = _spin(0.0, 1_000_000.0, 2, 659.17, step=10.0,
+                              suffix=" V/(A·s)")
+        self._lim_spin = _spin(0.0, 200.0, 3, 12.0, step=0.1, suffix=" V")
         mform.addRow("Kp", self._kp_spin)
         mform.addRow("Ki", self._ki_spin)
         mform.addRow("ILim", self._lim_spin)
@@ -88,12 +100,19 @@ class TuningPanel(QWidget):
         # --- MPZ retune ---
         mpz = QGroupBox("MPZ recompute")
         mfrm = QFormLayout(mpz)
-        self._r_spin = _spin(0, 1000, 4, self._last_motor_r, step=0.01)
-        self._l_spin = _spin(0, 10, 7, self._last_motor_l, step=0.0001)
-        self._bw_spin = _spin(1, 5000, 1, self._last_bw, step=10.0)
-        mfrm.addRow("R [Ω]", self._r_spin)
-        mfrm.addRow("L [H]", self._l_spin)
-        mfrm.addRow("Bandwidth [Hz]", self._bw_spin)
+        # L is stored in Henries but displayed in milli-Henries to keep the
+        # typing experience reasonable for normal motors (0.1 mH .. 100 mH).
+        # Conversions happen in _on_mpz and in _notify_params_changed.
+        self._r_spin = _spin(0.001, 1000.0, 4, self._last_motor_r,
+                             step=0.01, suffix=" Ω")
+        self._l_mh_spin = _spin(0.001, 10_000.0, 4,
+                                self._last_motor_l * 1000.0,
+                                step=0.01, suffix=" mH")
+        self._bw_spin = _spin(1.0, 5000.0, 1, self._last_bw,
+                              step=10.0, suffix=" Hz")
+        mfrm.addRow("R", self._r_spin)
+        mfrm.addRow("L", self._l_mh_spin)
+        mfrm.addRow("Bandwidth", self._bw_spin)
         btn_mpz = QPushButton("Recompute gains")
         btn_mpz.clicked.connect(self._on_mpz)
         mfrm.addRow(btn_mpz)
@@ -104,7 +123,7 @@ class TuningPanel(QWidget):
                                     self._last_bw,
                                     self._kp_spin.value(),
                                     self._ki_spin.value())
-        for spin in (self._r_spin, self._l_spin, self._bw_spin,
+        for spin in (self._r_spin, self._l_mh_spin, self._bw_spin,
                      self._kp_spin, self._ki_spin):
             spin.valueChanged.connect(self._notify_params_changed)
 
@@ -115,8 +134,8 @@ class TuningPanel(QWidget):
         self._override_box.toggled.connect(self._on_override_toggled)
         ovr_layout.addWidget(self._override_box)
         target_form = QFormLayout()
-        self._iq_spin = _spin(-50, 50, 4, 0.0, step=0.1)
-        self._id_spin = _spin(-50, 50, 4, 0.0, step=0.1)
+        self._iq_spin = _spin(-50.0, 50.0, 4, 0.0, step=0.1, suffix=" A")
+        self._id_spin = _spin(-50.0, 50.0, 4, 0.0, step=0.1, suffix=" A")
         self._iq_spin.setEnabled(False)
         self._id_spin.setEnabled(False)
         self._iq_spin.valueChanged.connect(self._on_iq_changed)
@@ -173,17 +192,18 @@ class TuningPanel(QWidget):
         self._notify_params_changed()
 
     def _on_mpz(self) -> None:
+        motor_l_h = self._l_mh_spin.value() * 1e-3  # mH -> H
         try:
             self._client.recompute_gains(
                 motor_r=self._r_spin.value(),
-                motor_l=self._l_spin.value(),
+                motor_l=motor_l_h,
                 bw_hz=self._bw_spin.value())
         except TunerError as e:
             self._status.setText(str(e))
             return
         self._status.setText("")
         self._last_motor_r = self._r_spin.value()
-        self._last_motor_l = self._l_spin.value()
+        self._last_motor_l = motor_l_h
         self._last_bw = self._bw_spin.value()
         # Wait a tick for the firmware to update, then refresh readouts
         # so the manual spinboxes line up with the new design.
@@ -231,7 +251,8 @@ class TuningPanel(QWidget):
     def _notify_params_changed(self) -> None:
         if self._on_params_changed is None:
             return
-        self._on_params_changed(self._r_spin.value(), self._l_spin.value(),
+        motor_l_h = self._l_mh_spin.value() * 1e-3  # mH -> H for the model
+        self._on_params_changed(self._r_spin.value(), motor_l_h,
                                 self._bw_spin.value(),
                                 self._kp_spin.value(), self._ki_spin.value())
 

--- a/tools/espfoc_studio/gui/tuning_panel.py
+++ b/tools/espfoc_studio/gui/tuning_panel.py
@@ -1,0 +1,244 @@
+"""Tuning panel: live gain readout, manual override, MPZ retune."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..protocol import AxisStateFlag, TunerClient, TunerError
+
+
+def _spin(maximum: float = 10000.0, minimum: float = -10000.0,
+          decimals: int = 4, value: float = 0.0,
+          step: float = 0.1) -> QDoubleSpinBox:
+    box = QDoubleSpinBox()
+    box.setRange(minimum, maximum)
+    box.setDecimals(decimals)
+    box.setSingleStep(step)
+    box.setValue(value)
+    return box
+
+
+class TuningPanel(QWidget):
+    """Left-hand side of the main window: controls + live readout.
+
+    All slots reach out to a TunerClient directly. We keep every
+    round-trip short so the UI does not feel janky even on real serial."""
+
+    def __init__(self, client: TunerClient,
+                 on_params_changed: Optional[Callable[[float, float, float,
+                                                       float, float], None]] = None) -> None:
+        super().__init__()
+        self._client = client
+        self._on_params_changed = on_params_changed
+        self._last_motor_r = 1.08
+        self._last_motor_l = 0.0018
+        self._last_bw = 150.0
+
+        root = QVBoxLayout(self)
+
+        # --- Axis state badge ---
+        self._state_label = QLabel("axis: disconnected")
+        self._state_label.setAlignment(Qt.AlignLeft)
+        self._state_label.setStyleSheet("font-family: monospace;")
+        root.addWidget(self._state_label)
+
+        # --- Live gains readout ---
+        live_box = QGroupBox("Live gains")
+        live_form = QFormLayout(live_box)
+        self._kp_label = QLabel("-")
+        self._ki_label = QLabel("-")
+        self._lim_label = QLabel("-")
+        self._vmax_label = QLabel("-")
+        for lbl in (self._kp_label, self._ki_label,
+                    self._lim_label, self._vmax_label):
+            lbl.setStyleSheet("font-family: monospace;")
+        live_form.addRow("Kp [V/A]", self._kp_label)
+        live_form.addRow("Ki [V/(A·s)]", self._ki_label)
+        live_form.addRow("ILim [V]", self._lim_label)
+        live_form.addRow("Vmax [V]", self._vmax_label)
+        root.addWidget(live_box)
+
+        # --- Manual gain editor ---
+        manual = QGroupBox("Manual gain override")
+        mform = QFormLayout(manual)
+        self._kp_spin = _spin(0, 500, 4, 1.46)
+        self._ki_spin = _spin(0, 1_000_000, 2, 659.17, 10.0)
+        self._lim_spin = _spin(0, 200, 3, 12.0)
+        mform.addRow("Kp", self._kp_spin)
+        mform.addRow("Ki", self._ki_spin)
+        mform.addRow("ILim", self._lim_spin)
+        btn_apply = QPushButton("Apply manual gains")
+        btn_apply.clicked.connect(self._on_apply_manual)
+        mform.addRow(btn_apply)
+        root.addWidget(manual)
+
+        # --- MPZ retune ---
+        mpz = QGroupBox("MPZ recompute")
+        mfrm = QFormLayout(mpz)
+        self._r_spin = _spin(0, 1000, 4, self._last_motor_r, step=0.01)
+        self._l_spin = _spin(0, 10, 7, self._last_motor_l, step=0.0001)
+        self._bw_spin = _spin(1, 5000, 1, self._last_bw, step=10.0)
+        mfrm.addRow("R [Ω]", self._r_spin)
+        mfrm.addRow("L [H]", self._l_spin)
+        mfrm.addRow("Bandwidth [Hz]", self._bw_spin)
+        btn_mpz = QPushButton("Recompute gains")
+        btn_mpz.clicked.connect(self._on_mpz)
+        mfrm.addRow(btn_mpz)
+        root.addWidget(mpz)
+        # Push any initial model to the Analysis view.
+        if self._on_params_changed is not None:
+            self._on_params_changed(self._last_motor_r, self._last_motor_l,
+                                    self._last_bw,
+                                    self._kp_spin.value(),
+                                    self._ki_spin.value())
+        for spin in (self._r_spin, self._l_spin, self._bw_spin,
+                     self._kp_spin, self._ki_spin):
+            spin.valueChanged.connect(self._notify_params_changed)
+
+        # --- Override + motion targets ---
+        ovr = QGroupBox("Tuner override / motion")
+        ovr_layout = QVBoxLayout(ovr)
+        self._override_box = QCheckBox("Override active")
+        self._override_box.toggled.connect(self._on_override_toggled)
+        ovr_layout.addWidget(self._override_box)
+        target_form = QFormLayout()
+        self._iq_spin = _spin(-50, 50, 4, 0.0, step=0.1)
+        self._id_spin = _spin(-50, 50, 4, 0.0, step=0.1)
+        self._iq_spin.setEnabled(False)
+        self._id_spin.setEnabled(False)
+        self._iq_spin.valueChanged.connect(self._on_iq_changed)
+        self._id_spin.valueChanged.connect(self._on_id_changed)
+        target_form.addRow("iq ref [A]", self._iq_spin)
+        target_form.addRow("id ref [A]", self._id_spin)
+        ovr_layout.addLayout(target_form)
+        root.addWidget(ovr)
+
+        # --- Status / errors bar ---
+        self._status = QLabel("")
+        self._status.setStyleSheet("color: #c62828;")
+        root.addWidget(self._status)
+        root.addStretch(1)
+
+    # --- Public slots (driven by MainWindow's timer) -----------------------
+
+    def poll(self) -> None:
+        """Refresh the live readout. Called periodically by MainWindow."""
+        try:
+            kp = self._client.read_kp()
+            ki = self._client.read_ki()
+            lim = self._client.read_int_lim()
+            vmax = self._client.read_v_max()
+            state = self._client.read_axis_state()
+        except TunerError as e:
+            self._status.setText(str(e))
+            return
+        self._status.setText("")
+        self._kp_label.setText(f"{kp:9.4f}")
+        self._ki_label.setText(f"{ki:9.2f}")
+        self._lim_label.setText(f"{lim:9.3f}")
+        self._vmax_label.setText(f"{vmax:9.3f}")
+        self._state_label.setText(f"axis: {self._format_state(state)}")
+        # Keep the override checkbox in sync without re-emitting signals.
+        override_active = bool(state & AxisStateFlag.TUNER_OVERRIDE)
+        self._override_box.blockSignals(True)
+        self._override_box.setChecked(override_active)
+        self._override_box.blockSignals(False)
+        self._iq_spin.setEnabled(override_active)
+        self._id_spin.setEnabled(override_active)
+
+    # --- Handlers ----------------------------------------------------------
+
+    def _on_apply_manual(self) -> None:
+        try:
+            self._client.write_kp(self._kp_spin.value())
+            self._client.write_ki(self._ki_spin.value())
+            self._client.write_int_lim(self._lim_spin.value())
+        except TunerError as e:
+            self._status.setText(str(e))
+            return
+        self._status.setText("")
+        self._notify_params_changed()
+
+    def _on_mpz(self) -> None:
+        try:
+            self._client.recompute_gains(
+                motor_r=self._r_spin.value(),
+                motor_l=self._l_spin.value(),
+                bw_hz=self._bw_spin.value())
+        except TunerError as e:
+            self._status.setText(str(e))
+            return
+        self._status.setText("")
+        self._last_motor_r = self._r_spin.value()
+        self._last_motor_l = self._l_spin.value()
+        self._last_bw = self._bw_spin.value()
+        # Wait a tick for the firmware to update, then refresh readouts
+        # so the manual spinboxes line up with the new design.
+        self.poll()
+        try:
+            self._kp_spin.blockSignals(True)
+            self._ki_spin.blockSignals(True)
+            self._kp_spin.setValue(self._client.read_kp())
+            self._ki_spin.setValue(self._client.read_ki())
+        except TunerError:
+            pass
+        finally:
+            self._kp_spin.blockSignals(False)
+            self._ki_spin.blockSignals(False)
+        self._notify_params_changed()
+
+    def _on_override_toggled(self, checked: bool) -> None:
+        try:
+            if checked:
+                self._client.override_on()
+            else:
+                self._client.override_off()
+        except TunerError as e:
+            self._status.setText(str(e))
+            self._override_box.blockSignals(True)
+            self._override_box.setChecked(not checked)
+            self._override_box.blockSignals(False)
+            return
+        self._status.setText("")
+        self._iq_spin.setEnabled(checked)
+        self._id_spin.setEnabled(checked)
+
+    def _on_iq_changed(self, value: float) -> None:
+        try:
+            self._client.write_target_iq(value)
+        except TunerError as e:
+            self._status.setText(str(e))
+
+    def _on_id_changed(self, value: float) -> None:
+        try:
+            self._client.write_target_id(value)
+        except TunerError as e:
+            self._status.setText(str(e))
+
+    def _notify_params_changed(self) -> None:
+        if self._on_params_changed is None:
+            return
+        self._on_params_changed(self._r_spin.value(), self._l_spin.value(),
+                                self._bw_spin.value(),
+                                self._kp_spin.value(), self._ki_spin.value())
+
+    @staticmethod
+    def _format_state(s: AxisStateFlag) -> str:
+        pretty = []
+        for flag in (AxisStateFlag.INITIALIZED, AxisStateFlag.ALIGNED,
+                     AxisStateFlag.RUNNING, AxisStateFlag.TUNER_OVERRIDE):
+            pretty.append(f"{'+' if s & flag else '-'}{flag.name}")
+        return " ".join(pretty)

--- a/tools/espfoc_studio/link/__init__.py
+++ b/tools/espfoc_studio/link/__init__.py
@@ -16,6 +16,7 @@ from .codec import (
     encode,
     Decoder,
 )
+from .transport import Transport, LoopbackTransport
 
 __all__ = [
     "SYNC",
@@ -29,4 +30,6 @@ __all__ = [
     "crc16_ccitt",
     "encode",
     "Decoder",
+    "Transport",
+    "LoopbackTransport",
 ]

--- a/tools/espfoc_studio/link/__init__.py
+++ b/tools/espfoc_studio/link/__init__.py
@@ -1,0 +1,32 @@
+"""Wire framing for the espFoC tuner protocol — Python mirror of
+source/motor_control/esp_foc_link.c. Cross-validated against the
+firmware-side encoder/decoder via tools/espfoc_studio/tests/.
+"""
+
+from .codec import (
+    SYNC,
+    HEADER_BYTES,
+    TRAILER_BYTES,
+    MAX_PAYLOAD,
+    MAX_FRAME,
+    Channel,
+    Status,
+    LinkError,
+    crc16_ccitt,
+    encode,
+    Decoder,
+)
+
+__all__ = [
+    "SYNC",
+    "HEADER_BYTES",
+    "TRAILER_BYTES",
+    "MAX_PAYLOAD",
+    "MAX_FRAME",
+    "Channel",
+    "Status",
+    "LinkError",
+    "crc16_ccitt",
+    "encode",
+    "Decoder",
+]

--- a/tools/espfoc_studio/link/__init__.py
+++ b/tools/espfoc_studio/link/__init__.py
@@ -17,6 +17,7 @@ from .codec import (
     Decoder,
 )
 from .transport import Transport, LoopbackTransport
+from .reader import LinkReader
 
 __all__ = [
     "SYNC",
@@ -32,4 +33,5 @@ __all__ = [
     "Decoder",
     "Transport",
     "LoopbackTransport",
+    "LinkReader",
 ]

--- a/tools/espfoc_studio/link/codec.py
+++ b/tools/espfoc_studio/link/codec.py
@@ -1,0 +1,194 @@
+"""Wire-level framing codec — mirror of source/motor_control/esp_foc_link.c.
+
+Frame layout (must stay byte-for-byte identical to the firmware):
+
+    offset  bytes  field
+    -----   -----  -----
+    0       1      sync = 0xA5
+    1       2      payload_len (LE)
+    3       1      channel
+    4       1      seq
+    5       N      payload
+    5+N     2      crc16 (LE, CRC-16/CCITT over channel..payload)
+
+The Python side stays sync-friendly (no asyncio) so the same code is
+reusable from a CLI, a Qt thread, or a pytest harness.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Optional
+
+
+SYNC = 0xA5
+HEADER_BYTES = 5  # sync + len(2) + channel + seq
+TRAILER_BYTES = 2  # crc16
+MAX_PAYLOAD = 256
+MAX_FRAME = HEADER_BYTES + MAX_PAYLOAD + TRAILER_BYTES
+
+
+class Channel(IntEnum):
+    TUNER = 0x01
+    SCOPE = 0x02
+    LOG = 0x03
+
+
+class Status(IntEnum):
+    OK = 0
+    INVALID_ARG = -1
+    TOO_BIG = -2
+    NEED_MORE = -3
+    BAD_SYNC = -4
+    BAD_CRC = -5
+
+
+class LinkError(Exception):
+    """Raised when an encode call cannot satisfy the request."""
+
+
+def crc16_ccitt(data: bytes) -> int:
+    """CRC-16/CCITT (poly 0x1021, init 0xFFFF, no reflection, no xor-out).
+
+    Bit-by-bit implementation that matches esp_foc_link_crc16() byte-for-byte.
+    """
+    crc = 0xFFFF
+    for b in data:
+        crc ^= b << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return crc
+
+
+def encode(channel: int, seq: int, payload: bytes = b"") -> bytes:
+    """Encode a single frame and return the wire bytes."""
+    if not isinstance(payload, (bytes, bytearray)):
+        raise LinkError("payload must be bytes-like")
+    if len(payload) > MAX_PAYLOAD:
+        raise LinkError(f"payload too big: {len(payload)} > {MAX_PAYLOAD}")
+    if not (0 <= channel <= 0xFF) or not (0 <= seq <= 0xFF):
+        raise LinkError("channel and seq must be u8")
+
+    n = len(payload)
+    head = bytes([
+        SYNC,
+        n & 0xFF, (n >> 8) & 0xFF,
+        channel & 0xFF,
+        seq & 0xFF,
+    ])
+    body = bytes(payload)
+    crc = crc16_ccitt(head[3:] + body)
+    trailer = bytes([crc & 0xFF, (crc >> 8) & 0xFF])
+    return head + body + trailer
+
+
+_DEC_WAIT_SYNC = 0
+_DEC_LEN_LO = 1
+_DEC_LEN_HI = 2
+_DEC_CHANNEL = 3
+_DEC_SEQ = 4
+_DEC_PAYLOAD = 5
+_DEC_CRC_LO = 6
+_DEC_CRC_HI = 7
+_DEC_DONE = 8
+
+
+@dataclass
+class Decoder:
+    """Streaming frame decoder. Mirrors esp_foc_link_decoder_t state."""
+
+    state: int = _DEC_WAIT_SYNC
+    channel: int = 0
+    seq: int = 0
+    payload_len: int = 0
+    payload: bytearray = field(default_factory=bytearray)
+    crc_recv: int = 0
+    crc_calc: int = 0xFFFF
+
+    def reset(self) -> None:
+        self.state = _DEC_WAIT_SYNC
+        self.channel = 0
+        self.seq = 0
+        self.payload_len = 0
+        self.payload = bytearray()
+        self.crc_recv = 0
+        self.crc_calc = 0xFFFF
+
+    @staticmethod
+    def _crc_update(crc: int, byte: int) -> int:
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+        return crc
+
+    def push(self, byte: int) -> Status:
+        """Feed one byte. Returns OK when a complete frame has been parsed."""
+        if not 0 <= byte <= 0xFF:
+            raise LinkError("byte must be 0..255")
+        if self.state == _DEC_DONE:
+            self.reset()
+
+        if self.state == _DEC_WAIT_SYNC:
+            if byte != SYNC:
+                return Status.NEED_MORE
+            self.state = _DEC_LEN_LO
+            return Status.NEED_MORE
+        if self.state == _DEC_LEN_LO:
+            self.payload_len = byte
+            self.state = _DEC_LEN_HI
+            return Status.NEED_MORE
+        if self.state == _DEC_LEN_HI:
+            self.payload_len |= byte << 8
+            if self.payload_len > MAX_PAYLOAD:
+                self.reset()
+                return Status.TOO_BIG
+            self.state = _DEC_CHANNEL
+            return Status.NEED_MORE
+        if self.state == _DEC_CHANNEL:
+            self.channel = byte
+            self.crc_calc = self._crc_update(self.crc_calc, byte)
+            self.state = _DEC_SEQ
+            return Status.NEED_MORE
+        if self.state == _DEC_SEQ:
+            self.seq = byte
+            self.crc_calc = self._crc_update(self.crc_calc, byte)
+            self.state = _DEC_CRC_LO if self.payload_len == 0 else _DEC_PAYLOAD
+            return Status.NEED_MORE
+        if self.state == _DEC_PAYLOAD:
+            self.payload.append(byte)
+            self.crc_calc = self._crc_update(self.crc_calc, byte)
+            if len(self.payload) >= self.payload_len:
+                self.state = _DEC_CRC_LO
+            return Status.NEED_MORE
+        if self.state == _DEC_CRC_LO:
+            self.crc_recv = byte
+            self.state = _DEC_CRC_HI
+            return Status.NEED_MORE
+        if self.state == _DEC_CRC_HI:
+            self.crc_recv |= byte << 8
+            if self.crc_recv != self.crc_calc:
+                self.reset()
+                return Status.BAD_CRC
+            self.state = _DEC_DONE
+            return Status.OK
+
+        self.reset()
+        return Status.BAD_SYNC
+
+    def feed(self, data: bytes) -> Optional["Decoder"]:
+        """Convenience helper: feed many bytes, return self when a frame
+        completes, or None when more bytes are needed."""
+        for b in data:
+            st = self.push(b)
+            if st == Status.OK:
+                return self
+            if st < 0 and st != Status.NEED_MORE:
+                raise LinkError(f"decode error: {st.name}")
+        return None

--- a/tools/espfoc_studio/link/reader.py
+++ b/tools/espfoc_studio/link/reader.py
@@ -40,7 +40,7 @@ class LinkReader:
 
         self._lock = threading.Lock()
         self._tuner_waiters: Dict[int, Queue] = {}
-        self._scope_cb: Optional[ScopeCallback] = None
+        self._scope_cbs: list[ScopeCallback] = []
         self._log_cb: Optional[LogCallback] = None
 
     # --- Lifecycle -------------------------------------------------------
@@ -73,9 +73,20 @@ class LinkReader:
 
     # --- Consumer registration ------------------------------------------
 
-    def register_scope_callback(self, cb: Optional[ScopeCallback]) -> None:
+    def register_scope_callback(self, cb: ScopeCallback) -> None:
+        """Append a scope handler; all subscribers are broadcast to."""
+        if cb is None:
+            return
         with self._lock:
-            self._scope_cb = cb
+            if cb not in self._scope_cbs:
+                self._scope_cbs.append(cb)
+
+    def unregister_scope_callback(self, cb: ScopeCallback) -> None:
+        with self._lock:
+            try:
+                self._scope_cbs.remove(cb)
+            except ValueError:
+                pass
 
     def register_log_callback(self, cb: Optional[LogCallback]) -> None:
         with self._lock:
@@ -123,8 +134,8 @@ class LinkReader:
             return
         if channel == int(Channel.SCOPE):
             with self._lock:
-                cb = self._scope_cb
-            if cb is not None:
+                cbs = list(self._scope_cbs)
+            for cb in cbs:
                 try:
                     cb(channel, seq, payload)
                 except Exception:

--- a/tools/espfoc_studio/link/reader.py
+++ b/tools/espfoc_studio/link/reader.py
@@ -1,0 +1,141 @@
+"""Shared reader for the espFoC link protocol.
+
+A single daemon thread consumes bytes from one Transport, feeds them
+through the streaming decoder and demuxes complete frames by channel:
+
+  * TUNER frames go to a per-seq Queue so TunerClient round-trips stay
+    synchronous and match requests to responses deterministically;
+  * SCOPE frames go to a user-registered callback (typically the GUI's
+    scope panel);
+  * LOG frames go to a user-registered callback (unused today, wired
+    up for the future tooling).
+
+The reader is designed to be shared: one physical bus → one reader →
+many consumers. This is the only model that makes sense once the scope
+stream starts flowing in parallel with tuner requests.
+"""
+
+from __future__ import annotations
+
+import threading
+from queue import Empty, Queue
+from typing import Callable, Dict, Optional
+
+from .codec import Channel, Decoder, Status
+from .transport import Transport
+
+
+ScopeCallback = Callable[[int, int, bytes], None]  # (channel, seq, payload)
+LogCallback = Callable[[int, bytes], None]          # (seq, payload)
+
+
+class LinkReader:
+    """Background reader + demuxer for a single Transport."""
+
+    def __init__(self, transport: Transport) -> None:
+        self.transport = transport
+        self._dec = Decoder()
+        self._thread: Optional[threading.Thread] = None
+        self._stop_flag = threading.Event()
+
+        self._lock = threading.Lock()
+        self._tuner_waiters: Dict[int, Queue] = {}
+        self._scope_cb: Optional[ScopeCallback] = None
+        self._log_cb: Optional[LogCallback] = None
+
+    # --- Lifecycle -------------------------------------------------------
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop_flag.clear()
+        self._thread = threading.Thread(target=self._run,
+                                        daemon=True,
+                                        name="espfoc-link-reader")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_flag.set()
+        try:
+            self.transport.close()
+        except Exception:
+            pass
+        if self._thread is not None:
+            self._thread.join(timeout=0.5)
+            self._thread = None
+        # Wake any waiters so they raise a timeout instead of hanging.
+        with self._lock:
+            for q in self._tuner_waiters.values():
+                try:
+                    q.put_nowait(None)
+                except Exception:
+                    pass
+
+    # --- Consumer registration ------------------------------------------
+
+    def register_scope_callback(self, cb: Optional[ScopeCallback]) -> None:
+        with self._lock:
+            self._scope_cb = cb
+
+    def register_log_callback(self, cb: Optional[LogCallback]) -> None:
+        with self._lock:
+            self._log_cb = cb
+
+    def register_tuner_waiter(self, seq: int) -> Queue:
+        q: Queue = Queue(maxsize=1)
+        with self._lock:
+            self._tuner_waiters[seq & 0xFF] = q
+        return q
+
+    def unregister_tuner_waiter(self, seq: int) -> None:
+        with self._lock:
+            self._tuner_waiters.pop(seq & 0xFF, None)
+
+    # --- Reader loop -----------------------------------------------------
+
+    def _run(self) -> None:
+        while not self._stop_flag.is_set():
+            try:
+                data = self.transport.read_bytes(128, timeout=0.1)
+            except Exception:
+                # transport closed under us; exit cleanly
+                return
+            if not data:
+                continue
+            for b in data:
+                st = self._dec.push(b)
+                if st == Status.OK:
+                    channel = self._dec.channel
+                    seq = self._dec.seq
+                    payload = bytes(self._dec.payload)
+                    self._dispatch(channel, seq, payload)
+                    self._dec.reset()
+
+    def _dispatch(self, channel: int, seq: int, payload: bytes) -> None:
+        if channel == int(Channel.TUNER):
+            with self._lock:
+                q = self._tuner_waiters.get(seq)
+            if q is not None:
+                try:
+                    q.put_nowait(payload)
+                except Exception:
+                    pass  # waiter already received something; drop duplicate
+            return
+        if channel == int(Channel.SCOPE):
+            with self._lock:
+                cb = self._scope_cb
+            if cb is not None:
+                try:
+                    cb(channel, seq, payload)
+                except Exception:
+                    pass
+            return
+        if channel == int(Channel.LOG):
+            with self._lock:
+                cb = self._log_cb
+            if cb is not None:
+                try:
+                    cb(seq, payload)
+                except Exception:
+                    pass
+            return

--- a/tools/espfoc_studio/link/transport.py
+++ b/tools/espfoc_studio/link/transport.py
@@ -7,6 +7,7 @@ target firmware was built against (UART, USB-CDC, ...).
 
 from __future__ import annotations
 
+import threading
 from typing import Optional
 
 
@@ -32,14 +33,21 @@ class Transport:
 class LoopbackTransport(Transport):
     """In-process transport that pipes the host side back to itself.
 
-    Useful for unit tests: pair two LoopbackTransport instances and any
-    bytes written into one show up on the other's read queue. The pair
-    is created via LoopbackTransport.pair().
+    Useful for unit tests and the GUI's --demo mode: pair two
+    LoopbackTransport instances and any bytes written into one show up
+    on the other's read queue.
+
+    read_bytes uses a Condition so a caller waiting for data does not
+    busy-loop; in practice this keeps the GUI event loop responsive
+    (otherwise two threads spinning on idle reads starve every other
+    Python thread including Qt's).
     """
 
     def __init__(self) -> None:
         self._tx_to: Optional["LoopbackTransport"] = None
         self._rx_buf = bytearray()
+        self._cond = threading.Condition()
+        self._closed = False
 
     @classmethod
     def pair(cls) -> tuple["LoopbackTransport", "LoopbackTransport"]:
@@ -51,14 +59,29 @@ class LoopbackTransport(Transport):
     def send_bytes(self, data: bytes) -> None:
         if self._tx_to is None:
             raise RuntimeError("LoopbackTransport is unpaired")
-        self._tx_to._rx_buf.extend(data)
+        peer = self._tx_to
+        with peer._cond:
+            if peer._closed:
+                return
+            peer._rx_buf.extend(data)
+            peer._cond.notify_all()
 
     def read_bytes(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
-        n = min(max_bytes, len(self._rx_buf))
-        chunk = bytes(self._rx_buf[:n])
-        del self._rx_buf[:n]
-        return chunk
+        if max_bytes <= 0:
+            return b""
+        with self._cond:
+            if not self._rx_buf and timeout is not None and timeout > 0:
+                # wait for data or timeout; Condition.wait returns early
+                # when notified so round-trips feel instant.
+                self._cond.wait(timeout=timeout)
+            n = min(max_bytes, len(self._rx_buf))
+            chunk = bytes(self._rx_buf[:n])
+            del self._rx_buf[:n]
+            return chunk
 
     def close(self) -> None:
+        with self._cond:
+            self._closed = True
+            self._rx_buf.clear()
+            self._cond.notify_all()
         self._tx_to = None
-        self._rx_buf.clear()

--- a/tools/espfoc_studio/link/transport.py
+++ b/tools/espfoc_studio/link/transport.py
@@ -1,0 +1,64 @@
+"""Transport abstractions for the espFoC link layer.
+
+Each transport class exposes a synchronous send_bytes / read_bytes pair.
+Higher-level code (protocol clients, GUI) picks one based on the bus the
+target firmware was built against (UART, USB-CDC, ...).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class Transport:
+    """Bare interface every concrete transport implements."""
+
+    def send_bytes(self, data: bytes) -> None:
+        raise NotImplementedError
+
+    def read_bytes(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+    def __enter__(self) -> "Transport":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+class LoopbackTransport(Transport):
+    """In-process transport that pipes the host side back to itself.
+
+    Useful for unit tests: pair two LoopbackTransport instances and any
+    bytes written into one show up on the other's read queue. The pair
+    is created via LoopbackTransport.pair().
+    """
+
+    def __init__(self) -> None:
+        self._tx_to: Optional["LoopbackTransport"] = None
+        self._rx_buf = bytearray()
+
+    @classmethod
+    def pair(cls) -> tuple["LoopbackTransport", "LoopbackTransport"]:
+        a, b = cls(), cls()
+        a._tx_to = b
+        b._tx_to = a
+        return a, b
+
+    def send_bytes(self, data: bytes) -> None:
+        if self._tx_to is None:
+            raise RuntimeError("LoopbackTransport is unpaired")
+        self._tx_to._rx_buf.extend(data)
+
+    def read_bytes(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
+        n = min(max_bytes, len(self._rx_buf))
+        chunk = bytes(self._rx_buf[:n])
+        del self._rx_buf[:n]
+        return chunk
+
+    def close(self) -> None:
+        self._tx_to = None
+        self._rx_buf.clear()

--- a/tools/espfoc_studio/link/transport_serial.py
+++ b/tools/espfoc_studio/link/transport_serial.py
@@ -1,0 +1,57 @@
+"""Serial-port transport (works for both UART and USB-CDC).
+
+pyserial is imported lazily so unit tests for the codec / protocol layers
+do not need pyserial installed.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .transport import Transport
+
+
+class SerialTransport(Transport):
+    def __init__(self, port: str, baud: int = 921600,
+                 read_timeout: float = 0.5,
+                 write_timeout: float = 1.0) -> None:
+        try:
+            import serial  # type: ignore
+        except ImportError as e:
+            raise RuntimeError(
+                "SerialTransport requires pyserial (pip install pyserial)"
+            ) from e
+        self._serial = serial.Serial(
+            port=port,
+            baudrate=baud,
+            timeout=read_timeout,
+            write_timeout=write_timeout,
+            bytesize=serial.EIGHTBITS,
+            parity=serial.PARITY_NONE,
+            stopbits=serial.STOPBITS_ONE,
+        )
+        # Some USB-CDC stacks discard initial bytes; flush garbage.
+        self._serial.reset_input_buffer()
+        self._serial.reset_output_buffer()
+
+    def send_bytes(self, data: bytes) -> None:
+        if not data:
+            return
+        self._serial.write(data)
+        self._serial.flush()
+
+    def read_bytes(self, max_bytes: int, timeout: Optional[float] = None) -> bytes:
+        if timeout is not None:
+            old = self._serial.timeout
+            self._serial.timeout = timeout
+            try:
+                return self._serial.read(max_bytes)
+            finally:
+                self._serial.timeout = old
+        return self._serial.read(max_bytes)
+
+    def close(self) -> None:
+        try:
+            self._serial.close()
+        except Exception:
+            pass

--- a/tools/espfoc_studio/model/__init__.py
+++ b/tools/espfoc_studio/model/__init__.py
@@ -1,0 +1,29 @@
+"""Motor / control analysis library for TunerStudio.
+
+Pure numpy; no Qt or GUI dependency. Reused by the GUI's Analysis tab,
+the CLI snapshot report, and the offline golden-vector tests.
+"""
+
+from .analysis import (
+    MotorParams,
+    PiGains,
+    mpz_design,
+    closed_loop_tf,
+    loop_gain_tf,
+    step_response,
+    bode,
+    pole_zero_map,
+    root_locus,
+)
+
+__all__ = [
+    "MotorParams",
+    "PiGains",
+    "mpz_design",
+    "closed_loop_tf",
+    "loop_gain_tf",
+    "step_response",
+    "bode",
+    "pole_zero_map",
+    "root_locus",
+]

--- a/tools/espfoc_studio/model/analysis.py
+++ b/tools/espfoc_studio/model/analysis.py
@@ -1,0 +1,199 @@
+"""Control-loop analysis helpers.
+
+All models mirror the firmware design:
+
+    plant   : G(s) = 1 / (R + L*s)   (first-order PMSM current loop)
+    ZOH     : alpha = exp(-R*Ts/L)
+    PI      : espFoC "delayed forward Euler" shape
+                  u[k]  = Kp*e[k] + I[k-1]
+                  I[k]  = I[k-1] + Ki*e[k]*Ts
+    MPZ     : Kp = R*(1 - beta)/(1 - alpha),  Ki = R*(1 - beta)/Ts
+              with beta = exp(-2*pi*bw_hz*Ts)
+
+Functions return numpy arrays; nothing here touches Qt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MotorParams:
+    """Motor parameters used everywhere in the analysis helpers."""
+    r_ohm: float     # phase resistance
+    l_h: float       # phase inductance
+    ts_s: float      # control-loop sample period
+    v_max: float = 12.0  # voltage ceiling (for anti-windup / saturation)
+
+    def __post_init__(self) -> None:
+        for name, v in (("r_ohm", self.r_ohm),
+                        ("l_h", self.l_h),
+                        ("ts_s", self.ts_s)):
+            if v <= 0:
+                raise ValueError(f"{name} must be positive, got {v}")
+
+
+@dataclass(frozen=True)
+class PiGains:
+    kp: float  # V/A
+    ki: float  # V/(A*s)
+    int_lim: float = 0.0  # integrator anti-windup clamp, volts
+
+
+# --- Design ------------------------------------------------------------------
+
+def mpz_design(motor: MotorParams, bandwidth_hz: float) -> PiGains:
+    """Run the same MPZ synthesis the firmware uses."""
+    if bandwidth_hz <= 0:
+        raise ValueError("bandwidth_hz must be positive")
+    if bandwidth_hz * motor.ts_s >= 0.5:
+        raise ValueError(
+            f"bandwidth {bandwidth_hz} Hz above Nyquist for Ts={motor.ts_s}s"
+        )
+    alpha = np.exp(-motor.r_ohm * motor.ts_s / motor.l_h)
+    beta = np.exp(-2.0 * np.pi * bandwidth_hz * motor.ts_s)
+    one_minus_alpha = 1.0 - alpha
+    one_minus_beta = 1.0 - beta
+    kp = motor.r_ohm * one_minus_beta / one_minus_alpha
+    ki = motor.r_ohm * one_minus_beta / motor.ts_s
+    return PiGains(kp=kp, ki=ki, int_lim=motor.v_max)
+
+
+# --- Transfer functions (discrete) ------------------------------------------
+
+def _plant_tf(motor: MotorParams) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (num, den) polynomials of the ZOH-discretized plant
+    G(z) = (1-alpha)/R * z^-1 / (1 - alpha z^-1).
+    Using positive-power polynomials: num = [(1-alpha)/R, 0] at order 1,
+    den = [1, -alpha]."""
+    alpha = np.exp(-motor.r_ohm * motor.ts_s / motor.l_h)
+    num = np.array([0.0, (1.0 - alpha) / motor.r_ohm])
+    den = np.array([1.0, -alpha])
+    return num, den
+
+
+def _pi_tf(gains: PiGains, ts_s: float) -> Tuple[np.ndarray, np.ndarray]:
+    """PI (delayed forward Euler) as positive-power polynomials:
+         C(z) = [Kp - (Kp - Ki*Ts) z^-1] / (1 - z^-1)
+       as positive powers: num_pos = [Kp, -(Kp - Ki*Ts)], den_pos = [1, -1].
+    """
+    num = np.array([gains.kp, -(gains.kp - gains.ki * ts_s)])
+    den = np.array([1.0, -1.0])
+    return num, den
+
+
+def _poly_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    return np.convolve(a, b)
+
+
+def _poly_add(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    n = max(len(a), len(b))
+    pa = np.concatenate([np.zeros(n - len(a)), a])
+    pb = np.concatenate([np.zeros(n - len(b)), b])
+    return pa + pb
+
+
+def loop_gain_tf(motor: MotorParams, gains: PiGains) -> Tuple[np.ndarray, np.ndarray]:
+    """L(z) = C(z) * G(z) — positive-power polynomials."""
+    cn, cd = _pi_tf(gains, motor.ts_s)
+    pn, pd = _plant_tf(motor)
+    num = _poly_mul(cn, pn)
+    den = _poly_mul(cd, pd)
+    return num, den
+
+
+def closed_loop_tf(motor: MotorParams, gains: PiGains) -> Tuple[np.ndarray, np.ndarray]:
+    """T(z) = L(z) / (1 + L(z))."""
+    ln, ld = loop_gain_tf(motor, gains)
+    num = ln
+    den = _poly_add(ld, ln)
+    return num, den
+
+
+# --- Simulation & frequency response ---------------------------------------
+
+def step_response(motor: MotorParams, gains: PiGains,
+                  n_samples: int = 200,
+                  reference: float = 1.0) -> Tuple[np.ndarray, np.ndarray]:
+    """Simulate the closed-loop step response to a unit step, using the
+    same PID structure the firmware implements. Returns (t, i)."""
+    alpha = np.exp(-motor.r_ohm * motor.ts_s / motor.l_h)
+    i = np.zeros(n_samples)
+    integ_prev = 0.0
+    integ = 0.0
+    u_max = motor.v_max
+    for k in range(n_samples - 1):
+        err = reference - i[k]
+        u = gains.kp * err + integ_prev
+        u = max(-u_max, min(u_max, u))
+        integ_prev = integ
+        integ = integ + gains.ki * err * motor.ts_s
+        if gains.int_lim > 0:
+            integ = max(-gains.int_lim, min(gains.int_lim, integ))
+        i[k + 1] = alpha * i[k] + (1.0 - alpha) / motor.r_ohm * u
+    t = np.arange(n_samples) * motor.ts_s
+    return t, i
+
+
+def bode(motor: MotorParams, gains: PiGains,
+         n_points: int = 400,
+         f_min_hz: float = 0.1,
+         f_max_hz: float = None) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return (freq_hz, magnitude_db, phase_deg) of the loop gain L(z)
+    evaluated at z = exp(j*2pi*f*Ts). Nyquist caps f at 1/(2*Ts)."""
+    nyquist = 1.0 / (2.0 * motor.ts_s)
+    if f_max_hz is None:
+        f_max_hz = 0.95 * nyquist
+    f_max_hz = min(f_max_hz, 0.99 * nyquist)
+    freqs = np.logspace(np.log10(f_min_hz), np.log10(f_max_hz), n_points)
+    num, den = loop_gain_tf(motor, gains)
+    z = np.exp(1j * 2.0 * np.pi * freqs * motor.ts_s)
+    # polyval evaluates highest-degree-first; our polys are already that form.
+    H = np.polyval(num, z) / np.polyval(den, z)
+    mag_db = 20.0 * np.log10(np.abs(H) + 1e-24)
+    phase_deg = np.unwrap(np.angle(H)) * 180.0 / np.pi
+    return freqs, mag_db, phase_deg
+
+
+def pole_zero_map(motor: MotorParams, gains: PiGains
+                  ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return (open_loop_poles, open_loop_zeros, closed_loop_poles, closed_loop_zeros)
+    as complex numpy arrays on the z-plane."""
+    ln, ld = loop_gain_tf(motor, gains)
+    cn, cd = closed_loop_tf(motor, gains)
+    ol_poles = np.roots(ld) if len(ld) > 1 else np.array([])
+    ol_zeros = np.roots(ln) if len(ln) > 1 else np.array([])
+    cl_poles = np.roots(cd) if len(cd) > 1 else np.array([])
+    cl_zeros = np.roots(cn) if len(cn) > 1 else np.array([])
+    return ol_poles, ol_zeros, cl_poles, cl_zeros
+
+
+def root_locus(motor: MotorParams, gains: PiGains,
+               scale_min: float = 0.05,
+               scale_max: float = 4.0,
+               n_points: int = 200) -> Tuple[np.ndarray, np.ndarray]:
+    """Trace the closed-loop poles as Kp is scaled from scale_min to scale_max
+    around the current design. Ki is kept proportional so the PI zero keeps
+    cancelling the plant pole (same ratio as the MPZ design).
+
+    Returns (k_values, poles) where poles.shape = (n_points, n_cl_poles).
+    """
+    ks = np.linspace(scale_min, scale_max, n_points)
+    k_ratio = gains.ki / gains.kp if gains.kp != 0 else 1.0
+    # Collect closed-loop poles for each scaled Kp.
+    all_poles = []
+    for k in ks:
+        scaled = PiGains(kp=gains.kp * k, ki=gains.kp * k * k_ratio,
+                         int_lim=gains.int_lim)
+        _, den = closed_loop_tf(motor, scaled)
+        all_poles.append(np.roots(den) if len(den) > 1 else np.array([]))
+    # Pad to square matrix so the caller can index per-pole trajectory.
+    n_max = max(len(p) for p in all_poles)
+    mat = np.full((n_points, n_max), np.nan + 1j * np.nan, dtype=complex)
+    for i, p in enumerate(all_poles):
+        mat[i, :len(p)] = p
+    return ks, mat

--- a/tools/espfoc_studio/protocol/__init__.py
+++ b/tools/espfoc_studio/protocol/__init__.py
@@ -1,0 +1,17 @@
+"""Tuner protocol client (mirror of include/espFoC/esp_foc_tuner.h)."""
+
+from .tuner import (
+    AxisStateFlag,
+    Op,
+    ParamId,
+    TunerError,
+    TunerClient,
+)
+
+__all__ = [
+    "AxisStateFlag",
+    "Op",
+    "ParamId",
+    "TunerError",
+    "TunerClient",
+]

--- a/tools/espfoc_studio/protocol/tuner.py
+++ b/tools/espfoc_studio/protocol/tuner.py
@@ -13,16 +13,14 @@ fixed-point format used everywhere in the firmware.
 from __future__ import annotations
 
 import struct
-import time
 from dataclasses import dataclass
 from enum import IntEnum, IntFlag
-from typing import Optional
+from queue import Empty
+from typing import Optional, Union
 
 from ..link import (
     Channel,
-    Decoder,
-    LinkError,
-    Status,
+    LinkReader,
     Transport,
     encode,
 )
@@ -116,15 +114,35 @@ def q16_to_float(v: int) -> float:
 
 
 class TunerClient:
-    """Send tuner requests over a Transport and wait for matching responses."""
+    """Send tuner requests over a Transport and wait for matching responses.
+
+    Under the hood every client shares a LinkReader with the rest of the
+    app (scope panel, log viewer, ...). Each round-trip parks itself on
+    a per-seq Queue, so concurrent scope traffic on the same bus can't
+    starve a pending tuner response.
+    """
 
     DEFAULT_TIMEOUT = 0.5  # seconds per round-trip
 
-    def __init__(self, transport: Transport, axis: int = 0) -> None:
-        self._t = transport
+    def __init__(self, transport_or_reader: Union[Transport, LinkReader],
+                 axis: int = 0) -> None:
         self._axis = axis
         self._seq = 0
-        self._dec = Decoder()
+        if isinstance(transport_or_reader, LinkReader):
+            self._reader = transport_or_reader
+            self._owns_reader = False
+        else:
+            self._reader = LinkReader(transport_or_reader)
+            self._reader.start()
+            self._owns_reader = True
+
+    @property
+    def reader(self) -> LinkReader:
+        return self._reader
+
+    def close(self) -> None:
+        if self._owns_reader:
+            self._reader.stop()
 
     def _next_seq(self) -> int:
         self._seq = (self._seq + 1) & 0xFF
@@ -139,32 +157,24 @@ class TunerClient:
             int(id_) & 0xFF, (int(id_) >> 8) & 0xFF,
             self._axis & 0xFF,
         ]) + cmd_payload
-        frame = encode(Channel.TUNER, seq, app)
-        self._t.send_bytes(frame)
-
-        deadline = time.monotonic() + (timeout if timeout is not None
-                                       else self.DEFAULT_TIMEOUT)
-        self._dec.reset()
-        while time.monotonic() < deadline:
-            data = self._t.read_bytes(64, timeout=0.05)
-            if not data:
-                continue
-            for b in data:
-                st = self._dec.push(b)
-                if st == Status.OK:
-                    if (self._dec.channel == int(Channel.TUNER) and
-                            self._dec.seq == seq):
-                        body = bytes(self._dec.payload)
-                        if len(body) < 2:
-                            raise TunerError(
-                                f"response too short ({len(body)} bytes)")
-                        status = struct.unpack("<b", body[:1])[0]
-                        return TunerResponse(status=status, payload=body[2:])
-                    # Frame for somebody else: keep looking
-                    self._dec.reset()
-                elif st < 0 and st != Status.NEED_MORE:
-                    raise TunerError(f"link decode error: {st.name}")
-        raise TunerError(f"timeout waiting for response (seq={seq})")
+        q = self._reader.register_tuner_waiter(seq)
+        try:
+            frame = encode(Channel.TUNER, seq, app)
+            self._reader.transport.send_bytes(frame)
+            try:
+                body = q.get(timeout=timeout if timeout is not None
+                             else self.DEFAULT_TIMEOUT)
+            except Empty:
+                raise TunerError(f"timeout waiting for response (seq={seq})")
+            if body is None:
+                raise TunerError("reader stopped")
+            if len(body) < 2:
+                raise TunerError(
+                    f"response too short ({len(body)} bytes)")
+            status = struct.unpack("<b", body[:1])[0]
+            return TunerResponse(status=status, payload=body[2:])
+        finally:
+            self._reader.unregister_tuner_waiter(seq)
 
     # --- High-level helpers -------------------------------------------------
 

--- a/tools/espfoc_studio/protocol/tuner.py
+++ b/tools/espfoc_studio/protocol/tuner.py
@@ -1,0 +1,251 @@
+"""Synchronous tuner protocol client.
+
+Wraps a Transport in the link codec and the application-level
+[op][id][axis][payload] envelope. Built around a single round-trip per
+call: send request, decode bytes until a tuner-channel response with the
+same seq comes back. The reactor on the firmware side is also synchronous,
+so this matches it without needing async io on the host.
+
+Q16.16 helpers convert between Python floats and the 32-bit signed
+fixed-point format used everywhere in the firmware.
+"""
+
+from __future__ import annotations
+
+import struct
+import time
+from dataclasses import dataclass
+from enum import IntEnum, IntFlag
+from typing import Optional
+
+from ..link import (
+    Channel,
+    Decoder,
+    LinkError,
+    Status,
+    Transport,
+    encode,
+)
+
+
+class Op(IntEnum):
+    READ = 0x01
+    WRITE = 0x02
+    EXEC = 0x03
+
+
+class ParamId(IntEnum):
+    # Read-only
+    KP_Q16          = 0x0010
+    KI_Q16          = 0x0011
+    INT_LIM_Q16     = 0x0012
+    V_MAX_Q16       = 0x0013
+    AXIS_STATE      = 0x0040
+    AXIS_LAST_ERR   = 0x0041
+    # Gain writes (atomic swap)
+    WRITE_KP        = 0x0020
+    WRITE_KI        = 0x0021
+    WRITE_INT_LIM   = 0x0022
+    # Motion targets (only honored while override is on)
+    WRITE_TARGET_ID = 0x0050
+    WRITE_TARGET_IQ = 0x0051
+    WRITE_TARGET_UD = 0x0052
+    WRITE_TARGET_UQ = 0x0053
+    # Commands (exec)
+    CMD_RECOMPUTE_GAINS = 0x0080
+    CMD_OVERRIDE_ON     = 0x00A0
+    CMD_OVERRIDE_OFF    = 0x00A1
+
+
+class AxisStateFlag(IntFlag):
+    INITIALIZED    = 1 << 0
+    ALIGNED        = 1 << 1
+    RUNNING        = 1 << 2
+    TUNER_OVERRIDE = 1 << 3
+
+
+# Mirror of esp_foc_err_t. Negative values indicate failure.
+ESP_FOC_OK = 0
+ESP_FOC_ERR_NOT_ALIGNED          = -1
+ESP_FOC_ERR_INVALID_ARG          = -2
+ESP_FOC_ERR_AXIS_INVALID_STATE   = -3
+ESP_FOC_ERR_ALIGNMENT_IN_PROGRESS = -4
+ESP_FOC_ERR_TIMESTEP_TOO_SMALL   = -5
+ESP_FOC_ERR_ROTOR_STARTUP        = -6
+ESP_FOC_ERR_ROTOR_STARTUP_PI     = -7
+
+
+_ERR_NAMES = {
+    ESP_FOC_OK: "OK",
+    ESP_FOC_ERR_NOT_ALIGNED: "NOT_ALIGNED",
+    ESP_FOC_ERR_INVALID_ARG: "INVALID_ARG",
+    ESP_FOC_ERR_AXIS_INVALID_STATE: "AXIS_INVALID_STATE",
+    ESP_FOC_ERR_ALIGNMENT_IN_PROGRESS: "ALIGNMENT_IN_PROGRESS",
+    ESP_FOC_ERR_TIMESTEP_TOO_SMALL: "TIMESTEP_TOO_SMALL",
+    ESP_FOC_ERR_ROTOR_STARTUP: "ROTOR_STARTUP",
+    ESP_FOC_ERR_ROTOR_STARTUP_PI: "ROTOR_STARTUP_PI",
+}
+
+
+def _err_name(code: int) -> str:
+    return _ERR_NAMES.get(code, f"errno {code}")
+
+
+class TunerError(Exception):
+    """Raised when the firmware returns a non-OK status, the response
+    times out, or the link layer fails to parse a frame."""
+
+
+@dataclass
+class TunerResponse:
+    status: int
+    payload: bytes
+
+
+def q16_from_float(x: float) -> int:
+    v = round(x * 65536.0)
+    if v > 0x7FFFFFFF:
+        v = 0x7FFFFFFF
+    if v < -0x80000000:
+        v = -0x80000000
+    return int(v)
+
+
+def q16_to_float(v: int) -> float:
+    return v / 65536.0
+
+
+class TunerClient:
+    """Send tuner requests over a Transport and wait for matching responses."""
+
+    DEFAULT_TIMEOUT = 0.5  # seconds per round-trip
+
+    def __init__(self, transport: Transport, axis: int = 0) -> None:
+        self._t = transport
+        self._axis = axis
+        self._seq = 0
+        self._dec = Decoder()
+
+    def _next_seq(self) -> int:
+        self._seq = (self._seq + 1) & 0xFF
+        return self._seq
+
+    def _round_trip(self, op: Op, id_: ParamId,
+                    cmd_payload: bytes = b"",
+                    timeout: Optional[float] = None) -> TunerResponse:
+        seq = self._next_seq()
+        app = bytes([
+            int(op),
+            int(id_) & 0xFF, (int(id_) >> 8) & 0xFF,
+            self._axis & 0xFF,
+        ]) + cmd_payload
+        frame = encode(Channel.TUNER, seq, app)
+        self._t.send_bytes(frame)
+
+        deadline = time.monotonic() + (timeout if timeout is not None
+                                       else self.DEFAULT_TIMEOUT)
+        self._dec.reset()
+        while time.monotonic() < deadline:
+            data = self._t.read_bytes(64, timeout=0.05)
+            if not data:
+                continue
+            for b in data:
+                st = self._dec.push(b)
+                if st == Status.OK:
+                    if (self._dec.channel == int(Channel.TUNER) and
+                            self._dec.seq == seq):
+                        body = bytes(self._dec.payload)
+                        if len(body) < 2:
+                            raise TunerError(
+                                f"response too short ({len(body)} bytes)")
+                        status = struct.unpack("<b", body[:1])[0]
+                        return TunerResponse(status=status, payload=body[2:])
+                    # Frame for somebody else: keep looking
+                    self._dec.reset()
+                elif st < 0 and st != Status.NEED_MORE:
+                    raise TunerError(f"link decode error: {st.name}")
+        raise TunerError(f"timeout waiting for response (seq={seq})")
+
+    # --- High-level helpers -------------------------------------------------
+
+    def _read_q16(self, id_: ParamId) -> float:
+        r = self._round_trip(Op.READ, id_)
+        if r.status != ESP_FOC_OK:
+            raise TunerError(f"read {id_.name} failed: {_err_name(r.status)}")
+        if len(r.payload) != 4:
+            raise TunerError(f"read {id_.name}: expected 4 bytes, got {len(r.payload)}")
+        return q16_to_float(struct.unpack("<i", r.payload)[0])
+
+    def _write_q16(self, id_: ParamId, value_float: float) -> None:
+        payload = struct.pack("<i", q16_from_float(value_float))
+        r = self._round_trip(Op.WRITE, id_, payload)
+        if r.status != ESP_FOC_OK:
+            raise TunerError(
+                f"write {id_.name}={value_float} failed: {_err_name(r.status)}")
+
+    def _exec(self, id_: ParamId, payload: bytes = b"") -> None:
+        r = self._round_trip(Op.EXEC, id_, payload)
+        if r.status != ESP_FOC_OK:
+            raise TunerError(f"exec {id_.name} failed: {_err_name(r.status)}")
+
+    # Public API ------------------------------------------------------------
+
+    def read_kp(self) -> float:
+        return self._read_q16(ParamId.KP_Q16)
+
+    def read_ki(self) -> float:
+        return self._read_q16(ParamId.KI_Q16)
+
+    def read_int_lim(self) -> float:
+        return self._read_q16(ParamId.INT_LIM_Q16)
+
+    def read_v_max(self) -> float:
+        return self._read_q16(ParamId.V_MAX_Q16)
+
+    def read_axis_state(self) -> AxisStateFlag:
+        r = self._round_trip(Op.READ, ParamId.AXIS_STATE)
+        if r.status != ESP_FOC_OK:
+            raise TunerError(f"read axis state failed: {_err_name(r.status)}")
+        if len(r.payload) != 1:
+            raise TunerError(
+                f"axis state response has {len(r.payload)} bytes, want 1")
+        return AxisStateFlag(r.payload[0])
+
+    def read_last_error(self) -> int:
+        r = self._round_trip(Op.READ, ParamId.AXIS_LAST_ERR)
+        if r.status != ESP_FOC_OK:
+            raise TunerError(f"read last err failed: {_err_name(r.status)}")
+        return struct.unpack("<b", r.payload[:1])[0]
+
+    def write_kp(self, kp: float) -> None:
+        self._write_q16(ParamId.WRITE_KP, kp)
+
+    def write_ki(self, ki: float) -> None:
+        self._write_q16(ParamId.WRITE_KI, ki)
+
+    def write_int_lim(self, lim: float) -> None:
+        self._write_q16(ParamId.WRITE_INT_LIM, lim)
+
+    def write_target_id(self, id_amps: float) -> None:
+        self._write_q16(ParamId.WRITE_TARGET_ID, id_amps)
+
+    def write_target_iq(self, iq_amps: float) -> None:
+        self._write_q16(ParamId.WRITE_TARGET_IQ, iq_amps)
+
+    def write_target_ud(self, ud_volts: float) -> None:
+        self._write_q16(ParamId.WRITE_TARGET_UD, ud_volts)
+
+    def write_target_uq(self, uq_volts: float) -> None:
+        self._write_q16(ParamId.WRITE_TARGET_UQ, uq_volts)
+
+    def recompute_gains(self, motor_r: float, motor_l: float, bw_hz: float) -> None:
+        payload = (struct.pack("<i", q16_from_float(motor_r))
+                   + struct.pack("<i", q16_from_float(motor_l))
+                   + struct.pack("<i", q16_from_float(bw_hz)))
+        self._exec(ParamId.CMD_RECOMPUTE_GAINS, payload)
+
+    def override_on(self) -> None:
+        self._exec(ParamId.CMD_OVERRIDE_ON)
+
+    def override_off(self) -> None:
+        self._exec(ParamId.CMD_OVERRIDE_OFF)

--- a/tools/espfoc_studio/requirements.txt
+++ b/tools/espfoc_studio/requirements.txt
@@ -1,0 +1,7 @@
+# Runtime dependencies for espfoc_studio (CLI + GUI).
+pyserial>=3.5
+numpy>=1.23
+
+# GUI only; safe to skip when using the CLI headlessly.
+PySide6>=6.5
+pyqtgraph>=0.13

--- a/tools/espfoc_studio/tests/test_analysis.py
+++ b/tools/espfoc_studio/tests/test_analysis.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/espfoc_studio/model/analysis.py.
+
+Pure math, no Qt; safe to run in CI or headless dev boxes.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))
+
+from espfoc_studio.model import (
+    MotorParams,
+    PiGains,
+    bode,
+    closed_loop_tf,
+    loop_gain_tf,
+    mpz_design,
+    pole_zero_map,
+    root_locus,
+    step_response,
+)
+
+
+def test_mpz_design_matches_gen_pi_gains():
+    """Design helper must agree with scripts/gen_pi_gains.py on the
+    reference gimbal motor."""
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.001, v_max=12.0)
+    g = mpz_design(motor, bandwidth_hz=150.0)
+    # Values match the golden iPower gimbal entry.
+    assert abs(g.kp - 1.460955) < 2e-3
+    assert abs(g.ki - 659.166) < 1.0
+
+
+def test_step_response_reaches_reference():
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.0001, v_max=24.0)
+    g = mpz_design(motor, bandwidth_hz=200.0)
+    t, i = step_response(motor, g, n_samples=4000, reference=1.0)
+    steady = np.mean(i[-50:])
+    assert abs(steady - 1.0) < 0.05, f"did not settle: steady={steady}"
+
+
+def test_step_response_rise_time_matches_bandwidth():
+    """First-order target: 63.2% at t = 1/w_bw."""
+    bw = 200.0
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.0001, v_max=24.0)
+    g = mpz_design(motor, bandwidth_hz=bw)
+    t, i = step_response(motor, g, n_samples=4000, reference=1.0)
+    idx = np.searchsorted(i, 0.632)
+    t_meas = t[idx]
+    t_expected = 1.0 / (2.0 * math.pi * bw)
+    rel = abs(t_meas - t_expected) / t_expected
+    # ~13% typical residual because the firmware PI is a delayed
+    # forward-Euler, introducing a 1-sample lag over the ideal target.
+    assert rel < 0.20, f"rise-time off: meas={t_meas}, expected={t_expected}"
+
+
+def test_bode_crosses_0db_near_bandwidth():
+    """Loop-gain magnitude crosses 0 dB near the designed bandwidth."""
+    bw = 150.0
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.001, v_max=12.0)
+    g = mpz_design(motor, bandwidth_hz=bw)
+    f, mag, _ = bode(motor, g, n_points=400)
+    crossover = f[np.argmin(np.abs(mag))]
+    assert 0.5 * bw <= crossover <= 1.5 * bw, (
+        f"crossover {crossover} Hz should be near {bw} Hz"
+    )
+
+
+def test_closed_loop_poles_inside_unit_circle():
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.001, v_max=12.0)
+    g = mpz_design(motor, bandwidth_hz=150.0)
+    _, _, cl_poles, _ = pole_zero_map(motor, g)
+    # All closed-loop poles must be strictly inside the unit circle.
+    assert np.all(np.abs(cl_poles) < 1.0), (
+        f"CL pole outside unit circle: {cl_poles}"
+    )
+
+
+def test_pi_zero_cancels_plant_pole():
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.001, v_max=12.0)
+    g = mpz_design(motor, bandwidth_hz=150.0)
+    _, ol_zeros, _, _ = pole_zero_map(motor, g)
+    alpha = math.exp(-motor.r_ohm * motor.ts_s / motor.l_h)
+    # One of the open-loop zeros comes from the PI and must sit at alpha.
+    assert any(abs(z - alpha) < 1e-6 for z in ol_zeros), (
+        f"no PI zero near alpha={alpha} in {ol_zeros}"
+    )
+
+
+def test_root_locus_shrinks_for_lower_kp():
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.001, v_max=12.0)
+    g = mpz_design(motor, bandwidth_hz=150.0)
+    ks, mat = root_locus(motor, g, scale_min=0.1, scale_max=2.0, n_points=50)
+    # At Kp scale ~ 0.1 poles should be slower (further from 0) than at 2.0;
+    # for this first-order-with-cancellation structure they approach z=1
+    # as Kp decreases.
+    slow = np.nanmax(np.abs(mat[0]))
+    fast = np.nanmax(np.abs(mat[-1]))
+    assert slow > fast, (
+        f"expected slower pole for lower Kp: slow={slow}, fast={fast}"
+    )
+
+
+def test_loop_gain_tf_shape():
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.001, v_max=12.0)
+    g = mpz_design(motor, bandwidth_hz=150.0)
+    num, den = loop_gain_tf(motor, g)
+    # 2nd-order numerator, 2nd-order denominator.
+    assert len(num) == 3
+    assert len(den) == 3
+
+
+def test_closed_loop_tf_shape():
+    motor = MotorParams(r_ohm=1.08, l_h=0.0018, ts_s=0.001, v_max=12.0)
+    g = mpz_design(motor, bandwidth_hz=150.0)
+    num, den = closed_loop_tf(motor, g)
+    assert len(num) == 3
+    assert len(den) == 3
+
+
+def main() -> int:
+    tests = [
+        test_mpz_design_matches_gen_pi_gains,
+        test_step_response_reaches_reference,
+        test_step_response_rise_time_matches_bandwidth,
+        test_bode_crosses_0db_near_bandwidth,
+        test_closed_loop_poles_inside_unit_circle,
+        test_pi_zero_cancels_plant_pole,
+        test_root_locus_shrinks_for_lower_kp,
+        test_loop_gain_tf_shape,
+        test_closed_loop_tf_shape,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"OK    {t.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e}")
+    if failed:
+        print(f"\n{failed} test(s) failed", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/espfoc_studio/tests/test_gui_smoke.py
+++ b/tools/espfoc_studio/tests/test_gui_smoke.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Headless smoke test of the GUI demo pipeline.
+
+Exercises the same path as `python -m espfoc_studio.gui --demo` but
+closes the window after a couple of timer ticks so the test is cheap
+and hermetic. QT_QPA_PLATFORM=offscreen makes this run on CI boxes
+with no display.
+
+Run:
+    QT_QPA_PLATFORM=offscreen PYTHONPATH=tools \
+        python3 tools/espfoc_studio/tests/test_gui_smoke.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
+
+from espfoc_studio.gui.demo_firmware import DemoFirmware
+from espfoc_studio.gui.main_window import MainWindow
+from espfoc_studio.link import LoopbackTransport
+from espfoc_studio.protocol import TunerClient
+
+
+def test_mainwindow_demo_boots_and_polls():
+    host_t, fw_t = LoopbackTransport.pair()
+    fw = DemoFirmware(fw_t)
+    fw.start()
+    try:
+        client = TunerClient(host_t)
+        app = QApplication.instance() or QApplication(sys.argv)
+        w = MainWindow(client, scope_source=fw.snapshot_plant,
+                       title="espFoC smoke")
+        w.show()
+        # Sanity: the initial gain readouts should materialize within a
+        # couple of timer ticks (200 ms). We drive the event loop manually
+        # so the test runs in ~1 s and exits.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            app.processEvents()
+            # Stop as soon as the Kp label has been populated.
+            if w._tuning._kp_label.text().strip() not in ("-", ""):
+                break
+            time.sleep(0.05)
+        assert w._tuning._kp_label.text().strip() not in ("-", ""), (
+            "tuning panel never received a gain update")
+        w.close()
+    finally:
+        fw.stop()
+
+
+def main() -> int:
+    tests = [test_mainwindow_demo_boots_and_polls]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"OK    {t.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e}")
+    if failed:
+        print(f"\n{failed} test(s) failed", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/espfoc_studio/tests/test_gui_smoke.py
+++ b/tools/espfoc_studio/tests/test_gui_smoke.py
@@ -44,25 +44,38 @@ def test_mainwindow_demo_boots_polls_and_streams_scope():
         apply_dark_theme(app)
         w = MainWindow(client, title="espFoC smoke")
         w.show()
+        # Engage the override and push a non-zero iq so the demo plant
+        # actually modulates — otherwise the SVM hexagon just sees zero
+        # vectors and looks idle.
+        client.override_on()
+        client.write_target_iq(1.5)
         # 1) the tuning panel must get a gain readout within a few ticks;
         # 2) the scope panel must see the CSV stream the demo firmware
         #    pushes (6 channels today), so its channel count grows
         #    beyond zero within a few scope frames.
-        deadline = time.monotonic() + 3.0
+        # 3) the SVM panel must collect enough alpha/beta samples to
+        #    draw at least a short trail.
+        deadline = time.monotonic() + 4.0
         tuning_seen = False
         scope_seen = False
+        svm_seen = False
         while time.monotonic() < deadline:
             app.processEvents()
             if w._tuning._kp_label.text().strip() not in ("-", ""):
                 tuning_seen = True
             if w._scope._n_channels > 0:
                 scope_seen = True
-            if tuning_seen and scope_seen:
+            if len(w._svm._alpha_buf) >= 5:
+                svm_seen = True
+            if tuning_seen and scope_seen and svm_seen:
                 break
             time.sleep(0.05)
         assert tuning_seen, "tuning panel never received a gain update"
         assert scope_seen, (
             "scope panel never received any SCOPE-channel frame"
+        )
+        assert svm_seen, (
+            "SVM panel never received enough samples to draw a trail"
         )
         w.close()
     finally:

--- a/tools/espfoc_studio/tests/test_gui_smoke.py
+++ b/tools/espfoc_studio/tests/test_gui_smoke.py
@@ -27,39 +27,51 @@ from PySide6.QtWidgets import QApplication
 
 from espfoc_studio.gui.demo_firmware import DemoFirmware
 from espfoc_studio.gui.main_window import MainWindow
-from espfoc_studio.link import LoopbackTransport
+from espfoc_studio.gui.theme import apply_dark_theme
+from espfoc_studio.link import LinkReader, LoopbackTransport
 from espfoc_studio.protocol import TunerClient
 
 
-def test_mainwindow_demo_boots_and_polls():
+def test_mainwindow_demo_boots_polls_and_streams_scope():
     host_t, fw_t = LoopbackTransport.pair()
     fw = DemoFirmware(fw_t)
     fw.start()
+    reader = LinkReader(host_t)
+    reader.start()
     try:
-        client = TunerClient(host_t)
+        client = TunerClient(reader)
         app = QApplication.instance() or QApplication(sys.argv)
-        w = MainWindow(client, scope_source=fw.snapshot_plant,
-                       title="espFoC smoke")
+        apply_dark_theme(app)
+        w = MainWindow(client, title="espFoC smoke")
         w.show()
-        # Sanity: the initial gain readouts should materialize within a
-        # couple of timer ticks (200 ms). We drive the event loop manually
-        # so the test runs in ~1 s and exits.
-        deadline = time.monotonic() + 2.0
+        # 1) the tuning panel must get a gain readout within a few ticks;
+        # 2) the scope panel must see the CSV stream the demo firmware
+        #    pushes (6 channels today), so its channel count grows
+        #    beyond zero within a few scope frames.
+        deadline = time.monotonic() + 3.0
+        tuning_seen = False
+        scope_seen = False
         while time.monotonic() < deadline:
             app.processEvents()
-            # Stop as soon as the Kp label has been populated.
             if w._tuning._kp_label.text().strip() not in ("-", ""):
+                tuning_seen = True
+            if w._scope._n_channels > 0:
+                scope_seen = True
+            if tuning_seen and scope_seen:
                 break
             time.sleep(0.05)
-        assert w._tuning._kp_label.text().strip() not in ("-", ""), (
-            "tuning panel never received a gain update")
+        assert tuning_seen, "tuning panel never received a gain update"
+        assert scope_seen, (
+            "scope panel never received any SCOPE-channel frame"
+        )
         w.close()
     finally:
         fw.stop()
+        reader.stop()
 
 
 def main() -> int:
-    tests = [test_mainwindow_demo_boots_and_polls]
+    tests = [test_mainwindow_demo_boots_polls_and_streams_scope]
     failed = 0
     for t in tests:
         try:

--- a/tools/espfoc_studio/tests/test_link_codec.py
+++ b/tools/espfoc_studio/tests/test_link_codec.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Cross-validation suite for the Python link codec.
+
+Two roles:
+  * Pure Python tests for encoder/decoder semantics (round-trip,
+    error paths, garbage skipping).
+  * Golden vectors that MUST agree byte-for-byte with the firmware
+    (test/test_link.c). Any drift here means firmware and host can
+    no longer talk to each other.
+
+Run from the component root:
+    PYTHONPATH=tools python3 tools/espfoc_studio/tests/test_link_codec.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))
+
+from espfoc_studio.link import (
+    Channel,
+    Decoder,
+    LinkError,
+    MAX_PAYLOAD,
+    Status,
+    crc16_ccitt,
+    encode,
+)
+
+
+def _expect_ok(status: Status, label: str) -> None:
+    if status != Status.OK:
+        raise AssertionError(f"{label}: expected OK, got {status.name}")
+
+
+def test_crc_golden_vectors():
+    """Must match the values asserted in test/test_link.c."""
+    assert crc16_ccitt(b"") == 0xFFFF
+    assert crc16_ccitt(b"\x00") == 0xE1F0
+    assert crc16_ccitt(b"HELLO") == 0x49D6
+
+
+def test_encode_roundtrip_small():
+    pl = bytes([0xDE, 0xAD, 0xBE, 0xEF])
+    frame = encode(Channel.TUNER, 0x42, pl)
+    dec = Decoder()
+    for b in frame[:-1]:
+        assert dec.push(b) == Status.NEED_MORE
+    assert dec.push(frame[-1]) == Status.OK
+    assert dec.channel == int(Channel.TUNER)
+    assert dec.seq == 0x42
+    assert bytes(dec.payload) == pl
+
+
+def test_encode_roundtrip_empty():
+    frame = encode(Channel.LOG, 0)
+    dec = Decoder()
+    for b in frame[:-1]:
+        assert dec.push(b) == Status.NEED_MORE
+    assert dec.push(frame[-1]) == Status.OK
+    assert dec.payload_len == 0
+    assert bytes(dec.payload) == b""
+
+
+def test_encode_roundtrip_max_payload():
+    pl = bytes((i ^ 0x55) & 0xFF for i in range(MAX_PAYLOAD))
+    frame = encode(Channel.SCOPE, 0xFF, pl)
+    dec = Decoder()
+    completed = dec.feed(frame)
+    assert completed is dec
+    assert dec.channel == int(Channel.SCOPE)
+    assert dec.seq == 0xFF
+    assert bytes(dec.payload) == pl
+
+
+def test_encode_rejects_oversized_payload():
+    try:
+        encode(Channel.TUNER, 0, bytes(MAX_PAYLOAD + 1))
+    except LinkError:
+        return
+    raise AssertionError("expected LinkError")
+
+
+def test_decoder_skips_garbage_until_sync():
+    pl = bytes([0x10, 0x20])
+    frame = encode(Channel.TUNER, 7, pl)
+    dec = Decoder()
+    for noise in [0x00, 0x11, 0xFF, 0x12, 0x34]:
+        assert dec.push(noise) == Status.NEED_MORE
+    completed = dec.feed(frame)
+    assert completed is dec
+    assert dec.seq == 7
+    assert bytes(dec.payload) == pl
+
+
+def test_decoder_flags_crc_corruption():
+    pl = bytes([0xCA, 0xFE])
+    frame = bytearray(encode(Channel.SCOPE, 1, pl))
+    frame[-1] ^= 0xFF  # flip CRC byte
+    dec = Decoder()
+    statuses = [dec.push(b) for b in frame]
+    # All earlier bytes either NEED_MORE; the final one must be BAD_CRC.
+    assert statuses[-1] == Status.BAD_CRC
+
+
+def test_decoder_recovers_after_bad_frame():
+    pl = bytes([0x01, 0x02, 0x03])
+    frame = encode(Channel.TUNER, 9, pl)
+    dec = Decoder()
+    # corrupt header (claims oversized payload)
+    assert dec.push(0xA5) == Status.NEED_MORE
+    assert dec.push(0xFF) == Status.NEED_MORE
+    assert dec.push(0xFF) == Status.TOO_BIG
+    # decoder must be reset; valid frame must parse
+    assert dec.feed(frame) is dec
+    assert bytes(dec.payload) == pl
+
+
+def test_cross_validation_against_firmware_pattern():
+    """The same payload encoded by Python must produce identical bytes
+    to what the firmware would emit. We re-derive the expected output by
+    construction (no firmware needed) so the test is self-contained."""
+    pl = bytes(range(8))
+    seq = 0x10
+    chan = Channel.TUNER
+    out = encode(chan, seq, pl)
+    # Header
+    assert out[0] == 0xA5
+    assert out[1] == len(pl) & 0xFF
+    assert out[2] == (len(pl) >> 8) & 0xFF
+    assert out[3] == int(chan)
+    assert out[4] == seq
+    # Payload
+    assert out[5:5 + len(pl)] == pl
+    # CRC over channel..payload (LE)
+    crc = crc16_ccitt(out[3:5 + len(pl)])
+    assert out[-2] == crc & 0xFF
+    assert out[-1] == (crc >> 8) & 0xFF
+
+
+def main() -> int:
+    tests = [
+        test_crc_golden_vectors,
+        test_encode_roundtrip_small,
+        test_encode_roundtrip_empty,
+        test_encode_roundtrip_max_payload,
+        test_encode_rejects_oversized_payload,
+        test_decoder_skips_garbage_until_sync,
+        test_decoder_flags_crc_corruption,
+        test_decoder_recovers_after_bad_frame,
+        test_cross_validation_against_firmware_pattern,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"OK    {t.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e}")
+    if failed:
+        print(f"\n{failed} test(s) failed", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/espfoc_studio/tests/test_tuner_protocol.py
+++ b/tools/espfoc_studio/tests/test_tuner_protocol.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""End-to-end test of the Python TunerClient against a Python "echo
+firmware" wired through an in-process loopback transport.
+
+The fake firmware mirrors enough of the C reactor to validate the
+protocol envelope, the seq matching, and the read/write/exec round-trips.
+The real firmware-side codec is exercised separately by the Unity tests
+(test_tuner_reactor.c). When the two suites agree, the wire format is
+known to be byte-for-byte compatible.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import sys
+import threading
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))
+
+from espfoc_studio.link import (
+    Channel,
+    Decoder,
+    LoopbackTransport,
+    Status,
+    encode,
+)
+from espfoc_studio.protocol import (
+    AxisStateFlag,
+    Op,
+    ParamId,
+    TunerClient,
+    TunerError,
+)
+
+
+class FakeFirmware(threading.Thread):
+    """Spins on a transport, decodes tuner-channel frames and emits
+    canned responses. Mirrors the dispatch logic of esp_foc_tuner.c
+    closely enough to flush out wire-level mismatches."""
+
+    def __init__(self, transport):
+        super().__init__(daemon=True)
+        self._t = transport
+        self._dec = Decoder()
+        self._stop = threading.Event()
+        # State the fake firmware "owns".
+        self.kp = 1.0
+        self.ki = 50.0
+        self.lim = 12.0
+        self.vmax = 12.0
+        self.aligned = True
+        self.override = False
+        self.target_iq = 0.0
+
+    def stop(self):
+        self._stop.set()
+
+    def _send_response(self, seq: int, status: int, payload: bytes = b""):
+        body = struct.pack("<bB", status, seq) + payload
+        self._t.send_bytes(encode(Channel.TUNER, seq, body))
+
+    def _q16(self, v: float) -> bytes:
+        raw = max(-0x80000000, min(0x7FFFFFFF, round(v * 65536.0)))
+        return struct.pack("<i", raw)
+
+    def _from_q16(self, data: bytes) -> float:
+        return struct.unpack("<i", data)[0] / 65536.0
+
+    def _dispatch(self, seq: int, payload: bytes):
+        if len(payload) < 4:
+            self._send_response(seq, -2)  # INVALID_ARG
+            return
+        op = payload[0]
+        pid = payload[1] | (payload[2] << 8)
+        # axis = payload[3]  # ignored by this fake
+        cmd = payload[4:]
+
+        if op == int(Op.READ):
+            if pid == int(ParamId.KP_Q16):
+                self._send_response(seq, 0, self._q16(self.kp))
+            elif pid == int(ParamId.KI_Q16):
+                self._send_response(seq, 0, self._q16(self.ki))
+            elif pid == int(ParamId.INT_LIM_Q16):
+                self._send_response(seq, 0, self._q16(self.lim))
+            elif pid == int(ParamId.V_MAX_Q16):
+                self._send_response(seq, 0, self._q16(self.vmax))
+            elif pid == int(ParamId.AXIS_STATE):
+                flags = AxisStateFlag.INITIALIZED
+                if self.aligned:
+                    flags |= AxisStateFlag.ALIGNED
+                if self.override:
+                    flags |= AxisStateFlag.TUNER_OVERRIDE
+                self._send_response(seq, 0, bytes([int(flags)]))
+            elif pid == int(ParamId.AXIS_LAST_ERR):
+                self._send_response(seq, 0, struct.pack("<b", 0))
+            else:
+                self._send_response(seq, -2)
+        elif op == int(Op.WRITE):
+            if len(cmd) < 4:
+                self._send_response(seq, -2)
+                return
+            v = self._from_q16(cmd[:4])
+            if pid == int(ParamId.WRITE_KP):
+                self.kp = v
+                self._send_response(seq, 0)
+            elif pid == int(ParamId.WRITE_KI):
+                self.ki = v
+                self._send_response(seq, 0)
+            elif pid == int(ParamId.WRITE_INT_LIM):
+                self.lim = v
+                self._send_response(seq, 0)
+            elif pid == int(ParamId.WRITE_TARGET_IQ):
+                if not self.override:
+                    self._send_response(seq, -3)  # AXIS_INVALID_STATE
+                    return
+                self.target_iq = v
+                self._send_response(seq, 0)
+            else:
+                self._send_response(seq, -2)
+        elif op == int(Op.EXEC):
+            if pid == int(ParamId.CMD_OVERRIDE_ON):
+                if not self.aligned:
+                    self._send_response(seq, -1)
+                    return
+                self.override = True
+                self._send_response(seq, 0)
+            elif pid == int(ParamId.CMD_OVERRIDE_OFF):
+                self.override = False
+                self._send_response(seq, 0)
+            elif pid == int(ParamId.CMD_RECOMPUTE_GAINS):
+                if len(cmd) < 12:
+                    self._send_response(seq, -2)
+                    return
+                # Mock MPZ recompute: just reflect that the call landed.
+                self.kp = self._from_q16(cmd[0:4]) * 5.0
+                self.ki = self._from_q16(cmd[4:8]) * 1000.0
+                self._send_response(seq, 0)
+            else:
+                self._send_response(seq, -2)
+        else:
+            self._send_response(seq, -2)
+
+    def run(self):
+        while not self._stop.is_set():
+            data = self._t.read_bytes(64, timeout=0.05)
+            if not data:
+                continue
+            for b in data:
+                st = self._dec.push(b)
+                if st == Status.OK:
+                    if self._dec.channel == int(Channel.TUNER):
+                        self._dispatch(self._dec.seq, bytes(self._dec.payload))
+                    self._dec.reset()
+
+
+def _setup():
+    host_t, fw_t = LoopbackTransport.pair()
+    fw = FakeFirmware(fw_t)
+    fw.start()
+    cli = TunerClient(host_t)
+    return cli, fw
+
+
+def test_read_pi_gains():
+    cli, fw = _setup()
+    try:
+        assert abs(cli.read_kp() - fw.kp) < 1e-3
+        assert abs(cli.read_ki() - fw.ki) < 1e-3
+        assert abs(cli.read_int_lim() - fw.lim) < 1e-3
+        assert abs(cli.read_v_max() - fw.vmax) < 1e-3
+    finally:
+        fw.stop()
+
+
+def test_write_then_read():
+    cli, fw = _setup()
+    try:
+        cli.write_kp(2.5)
+        cli.write_ki(123.4)
+        assert abs(cli.read_kp() - 2.5) < 1e-3
+        assert abs(cli.read_ki() - 123.4) < 1e-2
+    finally:
+        fw.stop()
+
+
+def test_axis_state_flags():
+    cli, fw = _setup()
+    try:
+        st = cli.read_axis_state()
+        assert AxisStateFlag.INITIALIZED in st
+        assert AxisStateFlag.ALIGNED in st
+        assert AxisStateFlag.TUNER_OVERRIDE not in st
+    finally:
+        fw.stop()
+
+
+def test_override_flow_then_motion():
+    cli, fw = _setup()
+    try:
+        cli.override_on()
+        st = cli.read_axis_state()
+        assert AxisStateFlag.TUNER_OVERRIDE in st
+        cli.write_target_iq(1.5)
+        assert abs(fw.target_iq - 1.5) < 1e-3
+        cli.override_off()
+    finally:
+        fw.stop()
+
+
+def test_motion_rejected_when_override_off():
+    cli, fw = _setup()
+    try:
+        try:
+            cli.write_target_iq(1.0)
+        except TunerError:
+            return
+        raise AssertionError("expected TunerError when override is off")
+    finally:
+        fw.stop()
+
+
+def test_recompute_gains():
+    cli, fw = _setup()
+    try:
+        cli.recompute_gains(1.08, 0.0018, 150.0)
+        assert abs(fw.kp - 1.08 * 5.0) < 1e-3
+        assert abs(fw.ki - 0.0018 * 1000.0) < 1e-3
+    finally:
+        fw.stop()
+
+
+def main() -> int:
+    tests = [
+        test_read_pi_gains,
+        test_write_then_read,
+        test_axis_state_flags,
+        test_override_flow_then_motion,
+        test_motion_rejected_when_override_off,
+        test_recompute_gains,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"OK    {t.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e}")
+    if failed:
+        print(f"\n{failed} test(s) failed", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Live tuning stack: firmware protocol, host CLI, TunerStudio GUI

This PR stitches the runtime tuner backend that already lived in espFoC
into a full operator workstation. The goal is to let anyone bring up a
motor interactively — align, step, tune, watch the SVPWM hexagon do its
thing — **without reflashing** the firmware once.   
   
## What ships

### Firmware

- **Runtime tuner protocol** — axis state query, MPZ recompute on the
  fly, manual override of `target_i_d / i_q / u_d / u_q` with bumpless
  transfer back to the user's regulation callback, and a `magic` field
  on `esp_foc_axis_t` that refuses every request targeting a stale or
  uninitialized axis.
- **Wire-level link codec** (`esp_foc_link.[ch]`) — SYNC + length +
  channel + seq + CRC-16/CCITT. Multiplexes tuner requests / responses,
  scope streams and (future) logs over a single bus.
- **Two production bridges** (UART for every ESP32, USB-CDC over
  TinyUSB for S2/S3/P4) both implementing the weak hooks already
  exposed by `esp_foc_tuner.h` and `esp_foc_scope.c`. Selected by
  Kconfig; mutually exclusive.

### Host

- **Python library** (`tools/espfoc_studio/`):
  - `link/` — codec, pyserial transport, in-process loopback for tests,
    and a single-reader-many-consumer `LinkReader` so tuner and scope
    never starve each other on the same physical line.
  - `protocol/` — synchronous `TunerClient` matching responses to
    requests by seq, Q16 conversion helpers.
  - `model/` — numpy helpers that mirror the firmware's discrete
    control loop (ZOH plant + delayed forward-Euler PI); Bode, step,
    pole/zero map, Kp-sweep root locus.
  - `cli/tunerctl.py` — argparse CLI: `axis-state`, `read`, `write`,
    `retune`, `override`, `set-target`.
- **TunerStudio GUI**:
  - Dark Fusion theme, no extra dependency beyond PySide6 + pyqtgraph.
  - Four tabs: Tuning, Analysis, Scope, SVM Hexagon.
  - Scope auto-discovers channel count from the CSV, colour-codes
    each one, and gives every channel a show/hide checkbox.
  - SVM tab draws the three phase rails plus live projection vectors
    whose sum (scaled by 2/3) is the resultant Vαβ — a live Clarke
    transform in picture form. The three-phase waveform below
    shows the actual SVPWM saddle shape with the min-max common-mode
    injection the firmware applies.
  - Every plot carries a crosshair with a formatted readout
    (`t / y`, `α / β`, `f / |L| dB`, `Re / Im`, etc).
  - A `--demo` flag spawns an embedded firmware simulator so the GUI
    runs end-to-end with no hardware in the loop.

## One-liner to try it

```bash
pip install -r tools/espfoc_studio/requirements.txt
PYTHONPATH=tools python3 -m espfoc_studio.gui --demo
