### PR TITLE
fix(tuner_studio_target): mandatory current sensor + move 3.0 changelog out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Targets: ESP32, ESP32-S3, ESP32-P4 (ESP-IDF v5+).
 > formula and the `motor_resistance / motor_inductance / motor_inertia`
 > fields are gone — gains come from the build-time autotuner or the
 > runtime tuner. The 3-PWM LEDC driver and the WIP `axis_sensorless`
-> example were also dropped. See [`CHANGELOG`](#changelog) below for
-> a full migration list.
+> example were also dropped. See [`changelog.txt`](changelog.txt) for
+> the full migration list.
 
 ---
 
@@ -236,28 +236,8 @@ espFoC/
 
 ## Changelog
 
-### 3.0
-
-* **Breaking:** `motor_resistance`, `motor_inductance` and
-  `motor_inertia` removed from `esp_foc_motor_control_settings_t`.
-  Gains come from the build-time autotuner or the runtime tuner.
-* **Breaking:** the 3-PWM LEDC inverter driver and
-  `CONFIG_ESP_FOC_ENABLE_LEGACY_LEDC_PWM` were dropped. Use the
-  3-PWM or 6-PWM MCPWM drivers.
-* **Breaking:** `examples/axis_sensorless` removed pending the
-  observer rework.
-* `esp_foc_align_axis()` now probes the rotor for its natural
-  direction and overrides the settings hint when the deflection is
-  conclusive.
-* New `esp_foc_calibration_*()` API and
-  `CONFIG_ESP_FOC_CALIBRATION_NVS` overlay calibration on top of
-  the autogen gains at boot, gated by a profile-hash for safety.
-* New tuner protocol commands: `CMD_ALIGN_AXIS`, `CMD_PERSIST_NVS`,
-  `CMD_LOAD_NVS`, `CMD_ERASE_NVS`, plus `PARAM_NVS_PRESENT` and
-  `PARAM_FIRMWARE_TYPE`.
-* New `examples/tuner_studio_target` service-mode firmware.
-* TunerStudio: alignment button, calibration save / load / erase,
-  LOG-channel viewer, Hardware tab and Generate App tab.
+Per-release notes live in [`changelog.txt`](changelog.txt) (consumed
+by the GitHub release notes generator).
 
 ---
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,38 @@ This file is used to generate GitHub releases. All versions from 2.0.0 onward ar
 
 ---
 
+## 3.0.0
+
+### BREAKING CHANGES (major)
+
+- **Settings struct slimmed down:** `motor_resistance`, `motor_inductance` and `motor_inertia` were removed from `esp_foc_motor_control_settings_t`. Current-loop gains come from the build-time MPZ autotuner (selected via `CONFIG_ESP_FOC_MOTOR_PROFILE`), the new NVS calibration overlay, or the runtime tuner. The old continuous-time formula was the maybe-good-maybe-not codepath and is gone.
+- **Legacy LEDC PWM driver removed:** `inverter_3pwm_ledc.[ch]` and `CONFIG_ESP_FOC_ENABLE_LEGACY_LEDC_PWM` are gone. Use the 3-PWM or 6-PWM MCPWM drivers.
+- **Sensorless example removed:** `examples/axis_sensorless/` was a placeholder behind a compile guard while the rotor-observer integration is reworked. It will return when the observer chain is wired into the axis again.
+- **Tuner motion-target IDs renumbered:** moved 0x0050..0x0053 → 0x0060..0x0063 to make room for `PARAM_FIRMWARE_TYPE` (0x0050). Affects only consumers that hardcode the wire IDs; the C symbols and the Python protocol mirror are updated in lockstep.
+
+### Features
+
+- **NVS calibration overlay** (`esp_foc_calibration_*` API). Tune live, save once, every subsequent boot comes up already tuned with no host attached. Each blob carries an FNV-1a profile hash of `<motor_profile>:<schema_version>` so a calibration tuned on motor A can never be silently loaded on motor B. Wire format: `[magic=0xE5F0CC11][version=1][profile_hash:u32][crc32:u32][payload_len:u16][pad][payload bytes]`. Gated by `CONFIG_ESP_FOC_CALIBRATION_NVS` (default y when the tuner backend is enabled).
+- **Auto natural-direction probe in `esp_foc_align_axis()`.** After the initial parking, the routine drives a short positive `Vq` pulse and watches the encoder delta to decide whether the encoder counts up or down on physical forward motion. `settings.natural_direction` becomes a hint used only when the rotor refuses to deflect (load-stuck, open phase, dead encoder).
+- **`tuner_studio_target` service-mode firmware** (`examples/tuner_studio_target`). Boots, parks the motor, attaches the axis to the runtime tuner, advertises `'TSGX'` through the new `esp_foc_tuner_firmware_type()` weak hook so TunerStudio recognises the target on connect. USB-CDC default on S3/P4, UART on plain ESP32.
+- **Tuner protocol additions:** `CMD_ALIGN_AXIS`, `CMD_PERSIST_NVS`, `CMD_LOAD_NVS`, `CMD_ERASE_NVS`, `PARAM_NVS_PRESENT`, `PARAM_FIRMWARE_TYPE`. Blocking commands stream progress on the LOG link channel so the GUI's log viewer / CLI can surface alignment and persistence status.
+- **TunerStudio:** Align button, Save / Load / Erase calibration buttons, calibration status indicator, LOG-channel viewer in the Tuning panel; new Hardware tab with target-aware GPIO / ADC dropdowns; new Generate App tab that renders a self-contained IDF project from the live tuning state plus the Hardware tab values, with a bit-exact `nvs_calibration.bin` when `nvs_partition_gen.py` is on `$IDF_PATH`. The Generate App tab is conditional on `firmware_type == 'TSGX'`.
+- **`tunerctl` CLI:** `align`, `persist`, `load`, `erase`, `firmware-type` subcommands.
+- **CI:** new `python_tests` job runs the host suite (link codec, tuner protocol, analysis, codegen, GUI smoke under `QT_QPA_PLATFORM=offscreen`); `tuner_studio_target` is built for esp32s3 (USB-CDC) + esp32 (UART) on every push.
+
+### Bug fixes
+
+- `idf_component.yml` `esp_tinyusb` rule used the wrong key (`idf_target` instead of `target`); the dependency was never auto-fetched on USB-capable targets. Fixed.
+- QEMU runner timed out flakily because Unity's prompt was raced; runner now expects `"Enter test for running"` explicitly and uses a 300 s timeout.
+- LinkReader / LoopbackTransport busy-looped reading 0 bytes when the demo firmware had nothing to send, starving the Qt event loop down to ~10 FPS. Switched to `threading.Condition` so reads block efficiently.
+
+### Other
+
+- Docs revamp: README is now concise and TunerStudio-first; deep tuning reference lives in `doc/TUNING.md`.
+- Internal: `esp_foc_initialize_axis()` lost ~35 lines of duplicated `#if` branching once the float fallback was deleted.
+
+---
+
 ## 2.0.0
 
 ### BREAKING CHANGES (major)

--- a/examples/tuner_studio_target/README.md
+++ b/examples/tuner_studio_target/README.md
@@ -10,10 +10,17 @@ at zero current and waits for the host to drive everything else
 ```bash
 cd examples/tuner_studio_target
 idf.py set-target esp32s3        # or esp32 / esp32p4
-idf.py menuconfig                # adjust the pin map under
+idf.py menuconfig                # adjust the pin map AND the ADC
+                                 # shunt config under
                                  # "TunerStudio target — pin map"
 idf.py build flash monitor
 ```
+
+The current sensor is mandatory: the Id/Iq PI loop has nothing to
+close on without measured currents, and the whole point of this
+firmware is to tune that loop. Defaults match the SimpleFOCShield
+(INA240A2 amp, 10 mΩ shunt, ADC1 channels 1 & 5) — adjust for
+your board before flashing.
 
 USB-CDC is the default transport (S2/S3/P4 only). On the original
 ESP32, switch to UART under `Component config` →

--- a/examples/tuner_studio_target/main/CMakeLists.txt
+++ b/examples/tuner_studio_target/main/CMakeLists.txt
@@ -1,2 +1,2 @@
 idf_component_register(SRC_DIRS "."
-                       PRIV_REQUIRES espFoC esp_system freertos esp_driver_i2c)
+                       PRIV_REQUIRES espFoC esp_system freertos esp_driver_i2c esp_adc)

--- a/examples/tuner_studio_target/main/Kconfig.projbuild
+++ b/examples/tuner_studio_target/main/Kconfig.projbuild
@@ -53,4 +53,36 @@ menu "TunerStudio target — pin map"
         range 1 64
         default 7
 
+    comment "ADC shunt current sensing"
+
+    config TUNER_TARGET_ISENSE_ADC_UNIT
+        int "ADC unit (1 or 2)"
+        range 1 2
+        default 1
+
+    config TUNER_TARGET_ISENSE_CH_U
+        int "ADC channel for phase U shunt"
+        range 0 9
+        default 1
+
+    config TUNER_TARGET_ISENSE_CH_V
+        int "ADC channel for phase V shunt"
+        range 0 9
+        default 5
+
+    config TUNER_TARGET_ISENSE_AMP_GAIN_X100
+        int "Current amplifier gain (V/V) x100"
+        range 1 100000
+        default 5000
+        help
+            Stored x100 because Kconfig int does not accept floats.
+            Default 5000 -> 50.0 V/V (typical INA240A2).
+
+    config TUNER_TARGET_ISENSE_SHUNT_MOHM
+        int "Shunt resistance (milli-ohm)"
+        range 1 10000
+        default 10
+        help
+            10 mOhm matches the SimpleFOCShield-style boards.
+
 endmenu

--- a/examples/tuner_studio_target/main/main.c
+++ b/examples/tuner_studio_target/main/main.c
@@ -22,6 +22,7 @@
 #include "espFoC/esp_foc_tuner.h"
 #include "espFoC/inverter_6pwm_mcpwm.h"
 #include "espFoC/rotor_sensor_as5600.h"
+#include "espFoC/current_sensor_adc.h"
 #include "espFoC/utils/esp_foc_q16.h"
 
 static const char *TAG = "tuner-target";
@@ -29,6 +30,7 @@ static const char *TAG = "tuner-target";
 static esp_foc_axis_t s_axis;
 static esp_foc_inverter_t *s_inverter;
 static esp_foc_rotor_sensor_t *s_rotor;
+static esp_foc_isensor_t *s_shunts;
 
 /* Advertise as a TunerStudio target so the GUI can light up its
  * Generate App tab on connect. */
@@ -96,19 +98,33 @@ void app_main(void)
         return;
     }
 
+    /* Current sensor is mandatory: the Id/Iq PI loop has no closed
+     * form without measured currents and the whole point of this
+     * firmware is to tune that loop. Pin assignments come from
+     * Kconfig (TUNER_TARGET_ISENSE_*). */
+    esp_foc_isensor_adc_config_t shunt_cfg = {
+        .axis_channels = {(adc_channel_t)CONFIG_TUNER_TARGET_ISENSE_CH_U,
+                          (adc_channel_t)CONFIG_TUNER_TARGET_ISENSE_CH_V},
+        .units         = {(adc_unit_t)(CONFIG_TUNER_TARGET_ISENSE_ADC_UNIT - 1),
+                          (adc_unit_t)(CONFIG_TUNER_TARGET_ISENSE_ADC_UNIT - 1)},
+        .amp_gain      = (float)CONFIG_TUNER_TARGET_ISENSE_AMP_GAIN_X100 / 100.0f,
+        .shunt_resistance = (float)CONFIG_TUNER_TARGET_ISENSE_SHUNT_MOHM / 1000.0f,
+        .number_of_channels = 2,
+    };
+    s_shunts = isensor_adc_new(&shunt_cfg);
+    if (s_shunts == NULL) {
+        ESP_LOGE(TAG, "current sensor init failed — current PI cannot run");
+        return;
+    }
+
     esp_foc_motor_control_settings_t settings = {
         .motor_pole_pairs  = CONFIG_TUNER_TARGET_POLE_PAIRS,
         .natural_direction = ESP_FOC_MOTOR_NATURAL_DIRECTION_CW,
         .motor_unit        = 0,
     };
 
-    /* Current sensor wiring is left out of this service firmware on
-     * purpose: voltage-mode tuning is enough to dial the loop in,
-     * and shipping a fixed shunt config would clash with whatever
-     * board the operator is using. The Generate App flow lets the
-     * user pick the ADC mode for the production firmware. */
     esp_foc_err_t err = esp_foc_initialize_axis(&s_axis, s_inverter,
-                                                s_rotor, NULL, settings);
+                                                s_rotor, s_shunts, settings);
     if (err != ESP_FOC_OK) {
         ESP_LOGE(TAG, "axis init failed: %d", err);
         return;


### PR DESCRIPTION
## Summary

Two follow-ups to the 3.0 PR (#30) that I missed before merge:

1. **`tuner_studio_target` shipped without a current sensor.** That defeats the firmware's own purpose: the Id/Iq PI loop the operator is there to tune has nothing to close on without measured currents. The original "voltage-mode tuning is enough" comment was wrong — voltage mode bypasses the current loop entirely, so a TunerStudio session against the bring-up firmware could never validate the gains it was producing. Fixed by wiring `isensor_adc_new()` into `app_main()` with the same continuous-ADC config `axis_sensored` uses, and adding per-board Kconfig entries for ADC unit / channels / amp gain / shunt resistance. Defaults match the SimpleFOCShield (INA240A2 50 V/V, 10 mΩ shunt, ADC1 channels 1 & 5). Boot-time `NULL` check refuses to attach the axis instead of silently sailing past — better to fail loud at init than to spin a motor with the current loop crippled.

2. **Changelog lived in two places.** `changelog.txt` is the canonical source the GitHub release generator reads (already had 2.0.0); the README was carrying a duplicate 3.0 list that would drift on the next bump. Moved the entry to `changelog.txt` under a `3.0.0` heading, replaced the README section with a one-line pointer.

## Validation

- `tuner_studio_target` builds clean for `esp32s3` (USB-CDC) and `esp32` (UART) locally.
- 203 / 203 Unity tests pass on QEMU (no library code touched).
- 30 / 30 host tests pass under `QT_QPA_PLATFORM=offscreen`.

## Test plan

- [x] CI green on the build job (axis_sensored, tuner_demo, tuner_studio_target s3 + esp32, test_drivers/*).
- [x] CI green on the python_tests job.
- [x] CI green on the QEMU unit_tests job (203 / 203).
