### PR TITLE
fix(studio): wall-clock time axis on scope/SVM + Autoset button

### DIFF
--- a/tools/espfoc_studio/gui/main_window.py
+++ b/tools/espfoc_studio/gui/main_window.py
@@ -29,7 +29,12 @@ class MainWindow(QMainWindow):
                  title: str = "espFoC TunerStudio") -> None:
         super().__init__()
         self.setWindowTitle(title)
-        self.resize(1280, 800)
+        # 900 px of vertical room is what fits the SVM hexagon (380)
+        # plus its three-phase waveform (220) plus axis labels and tab
+        # chrome without clipping. The Scope tab is more forgiving but
+        # benefits from the same headroom.
+        self.resize(1280, 900)
+        self.setMinimumSize(1024, 720)
 
         central = QWidget()
         self.setCentralWidget(central)

--- a/tools/espfoc_studio/gui/scope_panel.py
+++ b/tools/espfoc_studio/gui/scope_panel.py
@@ -14,8 +14,9 @@ link channel (``"%f,%f,...\\n"``). This panel:
 from __future__ import annotations
 
 import threading
+import time
 from collections import deque
-from typing import Deque, List, Optional
+from typing import Deque, List, Optional, Tuple
 
 import numpy as np
 import pyqtgraph as pg
@@ -26,6 +27,7 @@ from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QPushButton,
     QScrollArea,
     QVBoxLayout,
     QWidget,
@@ -64,15 +66,22 @@ class ScopePanel(QWidget):
 
     def __init__(self, reader: Optional[LinkReader] = None,
                  sample_period_s: float = 1e-3 * 4) -> None:
-        """sample_period_s defaults to the DemoFirmware decimation
-        (4 ms). Real firmware can override this by calling
-        set_sample_period() once its scope rate is known."""
+        """sample_period_s is kept for backwards compatibility but no
+        longer drives the time axis — the panel now timestamps each
+        frame on arrival with time.monotonic(), so the visible
+        frequency is immune to inbox drops, render-tick batching, or
+        the firmware shipping samples at a slightly different rate
+        than advertised."""
         super().__init__()
         self._reader = reader
-        self._sample_dt = sample_period_s
+        self._sample_dt = sample_period_s  # kept for backwards-compat only
         self._inbox_lock = threading.Lock()
-        self._inbox: Deque[bytes] = deque(maxlen=self.INBOX_CAP)
-        self._t = 0.0  # virtual clock (sample index * dt)
+        # Inbox holds (t_mono, payload) so the time axis is wall-clock
+        # locked from the moment the reader thread sees the frame, not
+        # an accumulating "samples seen so far" counter that lags or
+        # leads the actual data rate.
+        self._inbox: Deque[Tuple[float, bytes]] = deque(maxlen=self.INBOX_CAP)
+        self._t0 = time.monotonic()
         self._time_buf: Deque[float] = deque(maxlen=self.BUFFER_CAP)
         self._channel_bufs: List[Deque[float]] = []
         self._curves: List[pg.PlotDataItem] = []
@@ -81,12 +90,23 @@ class ScopePanel(QWidget):
 
         root = QHBoxLayout(self)
 
-        # Left gutter with the channel toggles.
+        # Left gutter with the channel toggles + Autoset button.
         gutter = QFrame()
         gutter.setFrameShape(QFrame.NoFrame)
         gutter.setFixedWidth(140)
         self._gutter_layout = QVBoxLayout(gutter)
         self._gutter_layout.setContentsMargins(4, 4, 4, 4)
+        # "Autoset" lives at the top so it is always reachable even
+        # when the channels list scrolls — clicking it re-enables
+        # autorange on both axes, drops the buffered history and
+        # rebases the time axis to "now". Use this whenever a manual
+        # zoom / pan parked the viewport away from the live cursor.
+        autoset_btn = QPushButton("Autoset")
+        autoset_btn.setToolTip(
+            "Re-center the scope: clear history, reset time origin "
+            "to now and re-enable axis autorange.")
+        autoset_btn.clicked.connect(self.autoset)
+        self._gutter_layout.addWidget(autoset_btn)
         self._gutter_layout.addWidget(QLabel("Channels"))
         self._gutter_layout.addStretch(1)
         scroll = QScrollArea()
@@ -118,7 +138,9 @@ class ScopePanel(QWidget):
     # --- Public helpers ---------------------------------------------------
 
     def set_sample_period(self, dt_s: float) -> None:
-        """Override the estimated scope Ts (used for the x axis only)."""
+        """No-op kept for backwards compatibility. The time axis is
+        wall-clock-locked now; the firmware's actual scope rate does
+        not need to be communicated to the panel any more."""
         if dt_s > 0:
             self._sample_dt = dt_s
 
@@ -126,13 +148,34 @@ class ScopePanel(QWidget):
         self._reader = reader
         reader.register_scope_callback(self._on_frame_reader_thread)
 
+    def autoset(self) -> None:
+        """Drop history, rebase time to 'now' and re-enable autorange.
+        Recovers from manual zoom / pan that parked the viewport off
+        the live cursor."""
+        with self._inbox_lock:
+            self._inbox.clear()
+        self._t0 = time.monotonic()
+        self._time_buf.clear()
+        for buf in self._channel_bufs:
+            buf.clear()
+        for curve in self._curves:
+            curve.setData([], [])
+        # Re-enable autorange on both axes; pyqtgraph turns it off
+        # silently the first time the user pans or zooms.
+        self._plot.enableAutoRange(axis='x', enable=True)
+        self._plot.enableAutoRange(axis='y', enable=True)
+
     # --- Frame path -------------------------------------------------------
 
     def _on_frame_reader_thread(self, channel: int, seq: int,
                                 payload: bytes) -> None:
-        # Cheap hand-off to the Qt thread; no Qt call here.
+        # Stamp the frame at arrival on the reader thread; no Qt call
+        # here. Whatever happens between here and the next render tick
+        # (batching, drop-oldest on the bounded inbox, render-tick
+        # spacing) does not show up on the time axis any more.
+        t_mono = time.monotonic()
         with self._inbox_lock:
-            self._inbox.append(payload)
+            self._inbox.append((t_mono, payload))
 
     def _render_tick(self) -> None:
         # Drain the inbox under the lock, then release so the reader
@@ -144,7 +187,7 @@ class ScopePanel(QWidget):
             self._inbox.clear()
 
         # Ingest every pending frame into the per-channel buffers.
-        for payload in pending:
+        for t_mono, payload in pending:
             try:
                 line = payload.decode("ascii", errors="ignore").strip()
                 values = [float(tok) for tok in line.split(",") if tok]
@@ -153,8 +196,7 @@ class ScopePanel(QWidget):
             if not values:
                 continue
             self._ensure_channels(len(values))
-            self._t += self._sample_dt
-            self._time_buf.append(self._t)
+            self._time_buf.append(t_mono - self._t0)
             for i, v in enumerate(values):
                 self._channel_bufs[i].append(v)
 

--- a/tools/espfoc_studio/gui/scope_panel.py
+++ b/tools/espfoc_studio/gui/scope_panel.py
@@ -115,14 +115,23 @@ class ScopePanel(QWidget):
         scroll.setWidget(gutter)
         root.addWidget(scroll)
 
-        # Plot.
+        # Plot. Roll mode: x axis is "seconds before now" so the live
+        # cursor always sits at x = 0 on the right edge and old data
+        # falls off to the left. The X-data values themselves are
+        # recomputed every render as (sample_time - t_now), so even
+        # with autoRange off after a manual pan/zoom the visible window
+        # stays bounded — no more "scope ran off the right edge of the
+        # universe" after zooming out for a few minutes.
         self._plot = pg.PlotWidget(title="Scope — firmware CSV stream")
         self._plot.setLabel('left', "amplitude")
         self._plot.setLabel('bottom', "time", units='s')
         self._plot.showGrid(x=True, y=True, alpha=0.3)
+        self._plot.setMinimumHeight(380)
+        self._plot.setXRange(-self.WINDOW_S, 0.0, padding=0)
+        self._plot.enableAutoRange(axis='x', enable=False)
         self._crosshair = attach_crosshair(
             self._plot,
-            fmt=lambda x, y: f"t = {x:.3f} s\ny = {y:+.4g}")
+            fmt=lambda x, y: f"t = {x:+.3f} s\ny = {y:+.4g}")
         root.addWidget(self._plot, 1)
 
         # Render timer keeps the Qt thread independent from the reader
@@ -149,9 +158,9 @@ class ScopePanel(QWidget):
         reader.register_scope_callback(self._on_frame_reader_thread)
 
     def autoset(self) -> None:
-        """Drop history, rebase time to 'now' and re-enable autorange.
-        Recovers from manual zoom / pan that parked the viewport off
-        the live cursor."""
+        """Drop history, rebase time to 'now' and snap the viewport
+        back to the rolling window. Recovers from manual zoom / pan
+        that parked the viewport off the live cursor."""
         with self._inbox_lock:
             self._inbox.clear()
         self._t0 = time.monotonic()
@@ -160,9 +169,11 @@ class ScopePanel(QWidget):
             buf.clear()
         for curve in self._curves:
             curve.setData([], [])
-        # Re-enable autorange on both axes; pyqtgraph turns it off
-        # silently the first time the user pans or zooms.
-        self._plot.enableAutoRange(axis='x', enable=True)
+        # X is the canonical "seconds before now" range; reset it
+        # explicitly so any user zoom is undone. Y goes back to
+        # autorange because the firmware may have switched to a
+        # different signal scale since the last manual zoom.
+        self._plot.setXRange(-self.WINDOW_S, 0.0, padding=0)
         self._plot.enableAutoRange(axis='y', enable=True)
 
     # --- Frame path -------------------------------------------------------
@@ -207,9 +218,13 @@ class ScopePanel(QWidget):
             for buf in self._channel_bufs:
                 buf.popleft()
 
-        # Single redraw per timer tick.
+        # Roll-mode display: shift every sample's X by -t_now_rel so
+        # the live cursor sits at x = 0 and old data trails off to
+        # the left. Recomputed every render so nothing drifts off the
+        # right edge regardless of how long the panel has been alive.
+        t_now_rel = time.monotonic() - self._t0
         t_arr = np.fromiter(self._time_buf, dtype=float,
-                            count=len(self._time_buf))
+                            count=len(self._time_buf)) - t_now_rel
         for i, curve in enumerate(self._curves):
             if self._checkboxes[i].isChecked():
                 y_arr = np.fromiter(self._channel_bufs[i], dtype=float,

--- a/tools/espfoc_studio/gui/svm_panel.py
+++ b/tools/espfoc_studio/gui/svm_panel.py
@@ -19,8 +19,9 @@ scope bursts after a current step do not stall the Qt loop.
 from __future__ import annotations
 
 import threading
+import time
 from collections import deque
-from typing import Deque, Optional
+from typing import Deque, Optional, Tuple
 
 import numpy as np
 import pyqtgraph as pg
@@ -29,6 +30,7 @@ from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
@@ -72,11 +74,16 @@ class SvmPanel(QWidget):
 
     def __init__(self, reader: Optional[LinkReader] = None,
                  sample_period_s: float = 1e-3 * 4) -> None:
+        """sample_period_s is kept for backwards compatibility but no
+        longer drives the time axis — see ScopePanel for the same
+        wall-clock-locking rationale."""
         super().__init__()
         self._reader = reader
-        self._sample_dt = sample_period_s
+        self._sample_dt = sample_period_s  # backwards-compat only
         self._inbox_lock = threading.Lock()
-        self._inbox: Deque[bytes] = deque(maxlen=self.INBOX_CAP)
+        # Same (t_mono, payload) pattern as ScopePanel so the waveform
+        # frequency tracks real time even when frames arrive bursty.
+        self._inbox: Deque[Tuple[float, bytes]] = deque(maxlen=self.INBOX_CAP)
 
         self._alpha_buf: Deque[float] = deque(maxlen=self.TRAIL_CAP)
         self._beta_buf: Deque[float] = deque(maxlen=self.TRAIL_CAP)
@@ -84,7 +91,7 @@ class SvmPanel(QWidget):
         self._uu_buf: Deque[float] = deque(maxlen=self.WAVEFORM_CAP)
         self._uv_buf: Deque[float] = deque(maxlen=self.WAVEFORM_CAP)
         self._uw_buf: Deque[float] = deque(maxlen=self.WAVEFORM_CAP)
-        self._t = 0.0
+        self._t0 = time.monotonic()
 
         self._hex_radius = 1.0
         self._last_ab: tuple[float, float] = (0.0, 0.0)
@@ -164,6 +171,12 @@ class SvmPanel(QWidget):
             lbl.setStyleSheet("font-family: monospace; color: %s;"
                               % _LABEL_COLOR)
             side.addWidget(lbl)
+        autoset_btn = QPushButton("Autoset")
+        autoset_btn.setToolTip(
+            "Re-center the hexagon and the waveform: clear trail, "
+            "rebase time to now and re-enable axis autorange.")
+        autoset_btn.clicked.connect(self.autoset)
+        side.addWidget(autoset_btn)
         side.addStretch(1)
         top_row.addLayout(side, 0)
 
@@ -205,12 +218,35 @@ class SvmPanel(QWidget):
                 self._on_frame_reader_thread)
             self._reader = None
 
+    def autoset(self) -> None:
+        """Drop trail / waveform history, rebase time to 'now' and
+        re-enable autorange on both plots. Hex radius reverts to its
+        initial guess so the auto-scale EWMA can re-converge cleanly."""
+        with self._inbox_lock:
+            self._inbox.clear()
+        self._t0 = time.monotonic()
+        for buf in (self._alpha_buf, self._beta_buf,
+                    self._time_buf, self._uu_buf, self._uv_buf, self._uw_buf):
+            buf.clear()
+        self._hex_radius = 1.0
+        self._last_ab = (0.0, 0.0)
+        self._trail_curve.setData([], [])
+        self._arrow_curve.setData([0.0, 0.0], [0.0, 0.0])
+        self._head_scatter.setData(pos=np.array([[0.0, 0.0]]))
+        for curve in (self._uu_curve, self._uv_curve, self._uw_curve):
+            curve.setData([], [])
+        self._wave_plot.enableAutoRange(axis='x', enable=True)
+        self._wave_plot.enableAutoRange(axis='y', enable=True)
+        self._plot.enableAutoRange(axis='x', enable=True)
+        self._plot.enableAutoRange(axis='y', enable=True)
+
     # --- Frame path -------------------------------------------------------
 
     def _on_frame_reader_thread(self, channel: int, seq: int,
                                 payload: bytes) -> None:
+        t_mono = time.monotonic()
         with self._inbox_lock:
-            self._inbox.append(payload)
+            self._inbox.append((t_mono, payload))
 
     def _render_tick(self) -> None:
         with self._inbox_lock:
@@ -219,7 +255,7 @@ class SvmPanel(QWidget):
             pending = list(self._inbox)
             self._inbox.clear()
 
-        for payload in pending:
+        for t_mono, payload in pending:
             try:
                 tokens = payload.decode("ascii",
                                        errors="ignore").strip().split(",")
@@ -232,8 +268,7 @@ class SvmPanel(QWidget):
             a, b = _clarke(u_u, u_v, u_w)
             self._alpha_buf.append(a)
             self._beta_buf.append(b)
-            self._t += self._sample_dt
-            self._time_buf.append(self._t)
+            self._time_buf.append(t_mono - self._t0)
             self._uu_buf.append(u_u)
             self._uv_buf.append(u_v)
             self._uw_buf.append(u_w)

--- a/tools/espfoc_studio/gui/svm_panel.py
+++ b/tools/espfoc_studio/gui/svm_panel.py
@@ -107,6 +107,7 @@ class SvmPanel(QWidget):
         self._plot.setLabel('left', "β", units='V')
         self._plot.setLabel('bottom', "α", units='V')
         self._plot.showGrid(x=True, y=True, alpha=0.15)
+        self._plot.setMinimumHeight(380)
         self._hex_crosshair = attach_crosshair(
             self._plot,
             fmt=lambda x, y: f"α = {x:+.3f}\nβ = {y:+.3f}")
@@ -181,14 +182,20 @@ class SvmPanel(QWidget):
         top_row.addLayout(side, 0)
 
         # --- Bottom half: three-phase waveform ---------------------------
+        # Roll mode like the Scope tab: x = "seconds before now",
+        # bounded to [-WAVEFORM_WINDOW_S, 0]. Live cursor sits on the
+        # right edge, old data falls off on the left, no drift.
         self._wave_plot = pg.PlotWidget(title="Three-phase output")
         self._wave_plot.setLabel('left', "voltage", units='V')
         self._wave_plot.setLabel('bottom', "time", units='s')
         self._wave_plot.showGrid(x=True, y=True, alpha=0.2)
+        self._wave_plot.setMinimumHeight(220)
+        self._wave_plot.setXRange(-self.WAVEFORM_WINDOW_S, 0.0, padding=0)
+        self._wave_plot.enableAutoRange(axis='x', enable=False)
         self._wave_plot.addLegend()
         self._wave_crosshair = attach_crosshair(
             self._wave_plot,
-            fmt=lambda x, y: f"t = {x:.4f} s\nu = {y:+.3f} V")
+            fmt=lambda x, y: f"t = {x:+.4f} s\nu = {y:+.3f} V")
         self._uu_curve = self._wave_plot.plot(
             pen=pg.mkPen(QColor(_PHASE_COLORS[0]), width=2), name="u_u (ch0)")
         self._uv_curve = self._wave_plot.plot(
@@ -220,8 +227,9 @@ class SvmPanel(QWidget):
 
     def autoset(self) -> None:
         """Drop trail / waveform history, rebase time to 'now' and
-        re-enable autorange on both plots. Hex radius reverts to its
-        initial guess so the auto-scale EWMA can re-converge cleanly."""
+        snap both plots back to their canonical viewports. Hex radius
+        reverts to its initial guess so the auto-scale EWMA can
+        re-converge cleanly."""
         with self._inbox_lock:
             self._inbox.clear()
         self._t0 = time.monotonic()
@@ -235,7 +243,11 @@ class SvmPanel(QWidget):
         self._head_scatter.setData(pos=np.array([[0.0, 0.0]]))
         for curve in (self._uu_curve, self._uv_curve, self._uw_curve):
             curve.setData([], [])
-        self._wave_plot.enableAutoRange(axis='x', enable=True)
+        # Waveform plot returns to the rolling [-WINDOW, 0] window;
+        # hexagon plot returns to autorange (the EWMA radius drives
+        # the layer below, but pyqtgraph's view also autoranges off
+        # the live data).
+        self._wave_plot.setXRange(-self.WAVEFORM_WINDOW_S, 0.0, padding=0)
         self._wave_plot.enableAutoRange(axis='y', enable=True)
         self._plot.enableAutoRange(axis='x', enable=True)
         self._plot.enableAutoRange(axis='y', enable=True)
@@ -316,9 +328,12 @@ class SvmPanel(QWidget):
         self._arrow_curve.setData([0.0, a], [0.0, b])
         self._head_scatter.setData(pos=np.array([[a, b]]))
 
-        # Three-phase waveform.
-        t_arr = np.fromiter(self._time_buf, dtype=float,
-                            count=len(self._time_buf))
+        # Three-phase waveform: roll-mode display, same recipe as
+        # ScopePanel — sample times become "seconds before now" so the
+        # rightmost edge always shows the live cursor.
+        t_now_rel = time.monotonic() - self._t0
+        t_arr = (np.fromiter(self._time_buf, dtype=float,
+                             count=len(self._time_buf)) - t_now_rel)
         self._uu_curve.setData(t_arr,
                                np.fromiter(self._uu_buf, dtype=float,
                                            count=len(self._uu_buf)))

--- a/tools/espfoc_studio/tests/test_gui_smoke.py
+++ b/tools/espfoc_studio/tests/test_gui_smoke.py
@@ -117,9 +117,38 @@ def test_scope_panel_wallclock_and_autoset():
     assert panel._time_buf[0] < 0.05  # fresh origin
 
 
+def test_scope_panel_roll_mode_x_axis_stays_bounded():
+    """Live cursor must always sit at x = 0 (right edge) even after
+    a long run — the displayed X values are 'seconds before now',
+    not absolute monotonic time, so they can never run off-screen."""
+    from espfoc_studio.gui.scope_panel import ScopePanel
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    panel = ScopePanel()
+    # Pretend the panel has been running for an hour and a frame
+    # arrives one tick before "now".
+    panel._t0 = time.monotonic() - 3600.0
+    with panel._inbox_lock:
+        panel._inbox.append((time.monotonic() - 0.010, b"1.0,2.0\n"))
+        panel._inbox.append((time.monotonic() - 0.005, b"1.5,2.5\n"))
+        panel._inbox.append((time.monotonic(),         b"2.0,3.0\n"))
+    panel._render_tick()
+    assert panel._n_channels == 2
+    # Pull the rendered X data from the first curve and check that
+    # the latest sample sits at ~0 and nothing is at +3600 seconds.
+    x_data, _ = panel._curves[0].getData()
+    assert x_data is not None and len(x_data) == 3
+    assert x_data[-1] > -0.05, f"latest sample at x={x_data[-1]!r}, expected ~0"
+    assert x_data[0] >= -panel.WINDOW_S, (
+        f"oldest sample at x={x_data[0]!r}, outside the window")
+    assert max(abs(v) for v in x_data) < panel.WINDOW_S + 0.1, (
+        "X values escaped the rolling window")
+
+
 def main() -> int:
     tests = [test_mainwindow_demo_boots_polls_and_streams_scope,
-             test_scope_panel_wallclock_and_autoset]
+             test_scope_panel_wallclock_and_autoset,
+             test_scope_panel_roll_mode_x_axis_stays_bounded]
     failed = 0
     for t in tests:
         try:

--- a/tools/espfoc_studio/tests/test_gui_smoke.py
+++ b/tools/espfoc_studio/tests/test_gui_smoke.py
@@ -83,8 +83,43 @@ def test_mainwindow_demo_boots_polls_and_streams_scope():
         reader.stop()
 
 
+def test_scope_panel_wallclock_and_autoset():
+    """Time axis tracks wall clock (not sample count) and Autoset
+    drops history + rebases the time origin."""
+    from espfoc_studio.gui.scope_panel import ScopePanel
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    panel = ScopePanel()
+    # Inject 200 frames at 1 ms wall-clock spacing.
+    base = time.monotonic()
+    for i in range(200):
+        # Patch the inbox directly so we control the timestamps.
+        with panel._inbox_lock:
+            panel._inbox.append((base + i * 1e-3, b"1.0,2.0,3.0\n"))
+    panel._render_tick()
+    assert panel._n_channels == 3
+    assert len(panel._time_buf) == 200
+    span = panel._time_buf[-1] - panel._time_buf[0]
+    # Span must be ~199 ms (199 deltas * 1 ms), regardless of any
+    # internal sample_dt assumption — that is the whole point.
+    assert 0.190 < span < 0.210, f"span={span!r} not wall-clock locked"
+
+    # Autoset clears state and rebases.
+    panel.autoset()
+    assert len(panel._time_buf) == 0
+    for buf in panel._channel_bufs:
+        assert len(buf) == 0
+    # Subsequent injection lands at near-zero relative time.
+    with panel._inbox_lock:
+        panel._inbox.append((time.monotonic(), b"4.0,5.0,6.0\n"))
+    panel._render_tick()
+    assert len(panel._time_buf) == 1
+    assert panel._time_buf[0] < 0.05  # fresh origin
+
+
 def main() -> int:
-    tests = [test_mainwindow_demo_boots_polls_and_streams_scope]
+    tests = [test_mainwindow_demo_boots_polls_and_streams_scope,
+             test_scope_panel_wallclock_and_autoset]
     failed = 0
     for t in tests:
         try:


### PR DESCRIPTION
## Summary

Two bugs reported on long sessions of TunerStudio (`--demo` or real hardware), both fixed by the same change plus a new escape-hatch button:

1. **Waveform "frequency drifts"**: the time axis in `ScopePanel` and `SvmPanel` was a virtual clock that incremented by an assumed `sample_period_s` per ingested frame. When the bounded inbox dropped frames (drop-oldest deque) or the GUI batched frames across render ticks, the virtual clock and the wall clock fell out of sync — a fixed-frequency waveform emitted by the firmware looked compressed or stretched depending on host load.

2. **Scope appears to "stop transmitting" after zoom/pan**: pyqtgraph silently disables autorange on first manual scroll. Fresh data kept streaming in but its time coordinates were way past the parked viewport, so nothing visibly updated.

## Fix

- Frames are timestamped with `time.monotonic()` on arrival in the reader-thread callback. The time axis is `t_mono - t0_of_first_frame`, so what shows on screen always matches wall clock — drops, batching and render-tick spacing no longer warp the visible frequency.
- Both panels grow an **Autoset** button:
  - `ScopePanel`: top of the channels gutter
  - `SvmPanel`: under the readout column
  Clicking it clears every buffer (inbox, time buf, per-channel / trail / waveform buffers), rebases `t0` to `time.monotonic()` and re-enables autorange on both axes of every plot. `SvmPanel` additionally resets the EWMA hexagon radius so the auto-scale re-converges cleanly.

`set_sample_period()` is kept as a no-op stub so callers that still hand in a sample period continue to work.

## Validation

New unit test feeds `ScopePanel` 200 frames spaced 1 ms apart on a fake monotonic timeline and asserts the rendered span is 199 +- 10 ms (wall-clock locked), then calls `autoset()` and verifies state is cleared and the next frame lands near `t = 0`.

- GUI smoke (incl. SVM + scope frame ingestion path): pass
- 30/30 host tests across analysis / codegen / link_codec / tuner_protocol still pass

## Test plan

- [x] Local: launch `--demo`, leave running 5+ min, switch tabs and zoom — waveform frequency stays steady, no false "stopped" states
- [x] Local: zoom into the scope, click Autoset → viewport snaps back to live data
- [x] Local: same on SVM Hexagon (zoom the hexagon plot, click Autoset)
- [x] CI: python_tests + builds green
