### PR TITLE
feat: FOC current loop inside the PWM ISR (Plan #2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(srcs    "source/motor_control/esp_foc_core.c"
             "source/motor_control/control_strategy/esp_foc_control_current_mode_sensored.c"
+            "source/motor_control/esp_foc_angle_predictor.c"
             "source/motor_control/esp_foc_biquad_q16.c"
             "source/motor_control/esp_foc_calibration.c"
             "source/motor_control/esp_foc_design_mpz.c"

--- a/Kconfig
+++ b/Kconfig
@@ -232,10 +232,16 @@ menu "espFoC Settings"
         config ESP_FOC_AUTOGEN_DECIMATION
             int "Current loop decimation factor the autotuner assumes"
             depends on ESP_FOC_USE_AUTOGEN_GAINS
+            default 1 if ESP_FOC_ISR_HOT_PATH
             default 20
             help
-                Should match ESP_FOC_LOW_SPEED_DOWNSAMPLING in
-                esp_foc_controls.h. Use 1 for ISR-mode control loops.
+                Tells the build-time autotuner what fs the runtime
+                current PI is going to see, expressed as
+                ESP_FOC_PWM_RATE_HZ / decimation. ISR_HOT_PATH=y
+                runs the loop straight off the PWM ISR, so the
+                effective decimation is 1; legacy task-mode loops
+                use ESP_FOC_LOW_SPEED_DOWNSAMPLING (20) which is the
+                default when the ISR path is disabled.
 
     endmenu
 

--- a/Kconfig
+++ b/Kconfig
@@ -154,6 +154,46 @@ menu "espFoC Settings"
             Matches the 2.x EMA default to keep behaviour the same
             after the EMA -> biquad swap.
 
+    config ESP_FOC_ISR_HOT_PATH
+        bool "Run the FOC current loop inside the PWM ISR"
+        default y
+        help
+            When enabled, Park / current PI / inverse Park / SVPWM /
+            set_voltages execute inside the MCPWM timer ISR at the
+            full PWM rate (40 kHz default). The user regulation
+            callback keeps running at pwm_rate / DOWNSAMPLING (still
+            2 kHz default), so user code rate is unchanged but the
+            inner current loop bandwidth ceiling jumps roughly 20x.
+
+            The slow encoder (AS5600 over I2C, AS5048 over SPI) is
+            read from the outer task; an alpha-beta predictor extrapolates
+            the electrical angle for every PWM cycle.
+
+            Set to n to fall back to the 2.x task-based control loop
+            (e.g. while a sensorless observer config that has not
+            been ported to the ISR path yet is in use).
+
+    config ESP_FOC_PREDICTOR_ALPHA_X1000
+        int "Angle predictor alpha (x1000)"
+        depends on ESP_FOC_ISR_HOT_PATH
+        range 1 1000
+        default 300
+        help
+            Measurement gain of the alpha-beta angle tracker, stored
+            x1000 because Kconfig int does not accept floats. Default
+            300 -> alpha = 0.300. Higher values track measurements
+            faster but amplify encoder noise.
+
+    config ESP_FOC_PREDICTOR_BETA_X1000
+        int "Angle predictor beta (x1000)"
+        depends on ESP_FOC_ISR_HOT_PATH
+        range 1 1000
+        default 50
+        help
+            Velocity gain of the alpha-beta tracker. Critical-damping
+            rule of thumb: beta = alpha^2 / (2 - alpha). Default
+            50 -> beta = 0.050.
+
     config ESP_FOC_INJECTION_ENABLE
         bool "Enable signal injection on the q-axis current reference"
         default n

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,8 +6,21 @@ This file is used to generate GitHub releases. All versions from 2.0.0 onward ar
 
 ## Unreleased
 
+### Features
+
+- **FOC current loop runs inside the PWM ISR.** Park / current PI / inverse Park / SVPWM / `set_voltages` execute at the full PWM rate (40 kHz default) instead of the legacy `pwm_rate / decimation` (2 kHz). The user `regulation_callback` keeps running on its task at 2 kHz so user code rate is unchanged; the inner current loop bandwidth ceiling jumps roughly 20x. Gated by `CONFIG_ESP_FOC_ISR_HOT_PATH` (default y); legacy 2.x task path stays available when n.
+- **Alpha-beta angle tracker** (`include/espFoC/utils/angle_predictor_q16.h`) bridges the slow encoder (AS5600 over I2C, ~2 kHz hard cap) and the fast ISR. Outer task feeds `update()` with each fresh reading; ISR queries `predict()` to get a fresh extrapolated electrical angle every PWM cycle. Defaults `alpha = 0.30`, `beta = 0.05` (overridable via `CONFIG_ESP_FOC_PREDICTOR_ALPHA_X1000` / `_BETA_X1000`).
+- **Clarke-publish path inside ADC drivers.** Both continuous and one-shot ADC drivers now apply offset + gain + Clarke right after the per-channel biquad in the ADC ISR and atomic-write `i_alpha` / `i_beta` into operator-supplied Q16 sinks. The PWM ISR reads the published values directly — zero blocking, zero critical sections in the hot path. Wired through the new `set_publish_targets()` interface method.
+- **`esp_foc_scope_data_push_from_isr()`** — ISR-safe variant of the scope push that uses `xTaskNotifyGiveFromISR`. Scope buffer storage flips from `float` to `q16_t` so the float conversion happens in the daemon thread (Xtensa FPU context save in ISRs is non-trivial).
+- **Build-time autotuner alignment.** `CONFIG_ESP_FOC_AUTOGEN_DECIMATION` defaults to 1 when ISR_HOT_PATH is on (matches the new loop rate); the PID controllers in core init pick `loop_dt = pwm_period` to integrate at the rate they actually fire at. No manual retune needed when flipping the flag.
+
+### Considered, ruled out
+
+- **Plan #3 — IPC offload of sin/cos to the other core.** `esp_ipc_isr_call` callback must be assembly on Xtensa, no async completion notification (only busy-wait variants), and the LUT-based sin+cos already runs in the order of hundreds of cycles — IPI round-trip would dwarf the win.
+
 ### BREAKING CHANGES (major)
 
+- **`esp_foc_isensor_t` interface grew `set_publish_targets`.** Existing user-supplied isensor implementations need to add the method (a no-op stub is acceptable).
 - **EMA helper retired.** `include/espFoC/utils/ema_low_pass_filter.h` and `esp_foc_lp_filter_t` are gone. Every consumer (current filtering, velocity estimate, PLL observer, KF observer) migrated to the new 2nd-order Butterworth biquad in `include/espFoC/utils/biquad_q16.h`. Application code that called `esp_foc_low_pass_filter_*` directly must port to `esp_foc_biquad_q16_*` and `esp_foc_biquad_butterworth_lpf_design_q16()`.
 - **`esp_foc_axis_t` shrank.** The two `current_filters[2]` EMAs are gone — the per-phase Butterworth lives inside the isensor driver, applied to raw ADC counts before the gain conversion. `velocity_filter` keeps its slot but switches type from `esp_foc_lp_filter_t` to `esp_foc_biquad_q16_t`.
 - **Moving-average dropped from both ADC drivers.** `current_sensor_adc.c` and `current_sensor_adc_one_shot.c` no longer buffer `ESP_FOC_LOW_SPEED_DOWNSAMPLING` samples per channel and average them. Each fresh count goes through a per-channel biquad inside the ADC ISR. Consumers see the same `fetch_isensors()` interface.

--- a/doc/TUNING.md
+++ b/doc/TUNING.md
@@ -196,6 +196,97 @@ Operators with hand-tuned observer cutoffs may want to revisit:
 the new filter has the same -3 dB position but a sharper roll-off
 (40 dB/decade vs 20 dB/decade) and slightly different phase.
 
+## ISR hot path (Plan #2)
+
+Set `CONFIG_ESP_FOC_ISR_HOT_PATH=y` (default) and the entire FOC
+inner loop — Park, current PI, inverse Park, SVPWM, `set_voltages`
+— runs inside the MCPWM timer ISR at the full PWM rate (40 kHz
+default). The user `regulation_callback` keeps running on its
+FreeRTOS task at `pwm_rate / ESP_FOC_LOW_SPEED_DOWNSAMPLING`
+(2 kHz default), so user code rate is unchanged. The current PI's
+sample rate climbs from 2 kHz to 40 kHz: a ~20x bandwidth headroom
+for free, no faster ADC needed.
+
+Three pieces work together:
+
+* **ADC ISR** (`source/drivers/current_sensor_adc.c` and the P4
+  one-shot variant): every fresh sample goes through the per-phase
+  Butterworth biquad, then the driver applies offset + gain +
+  Clarke and atomic-writes `i_alpha` / `i_beta` into the
+  axis-supplied sinks via the new `set_publish_targets()` interface
+  method. The PWM ISR can then read both currents with a single
+  load each — no critical section, no fetch_isensors call.
+
+* **PWM ISR** (`foc_hot_isr` in
+  `source/motor_control/control_strategy/esp_foc_control_current_mode_sensored.c`):
+  reads the published currents, asks the angle predictor for a fresh
+  electrical angle, runs Park + PI + inverse Park + SVPWM, calls
+  `set_voltages`, optionally pushes a scope frame via
+  `esp_foc_scope_data_push_from_isr()`, then decrements the
+  downsample counter and notifies the outer task on rollover.
+
+* **Outer task** (renamed in spirit, same symbol
+  `do_current_mode_sensored_low_speed_loop`): waits on the ISR's
+  notification, reads the slow encoder (AS5600 over I2C, AS5048
+  over SPI, or PCNT-direct), folds the new electrical angle into
+  the predictor under critical section, runs the velocity smoothing
+  biquad, then notifies the regulator task so the user
+  `regulation_callback` can refresh the targets.
+
+The slow encoder problem is solved with an **alpha-beta angle
+tracker** (`include/espFoC/utils/angle_predictor_q16.h`):
+
+```
+predict(t_now):
+    dt = t_now - t_last
+    return wrap_2pi(theta_est + omega_est * dt)
+
+update(theta_meas, t_meas):
+    dt = t_meas - t_last
+    theta_pred = wrap_2pi(theta_est + omega_est * dt)
+    err = wrap_pi(theta_meas - theta_pred)            in (-pi, +pi]
+    theta_est = wrap_2pi(theta_pred + alpha * err)
+    omega_est += (beta / dt) * err
+```
+
+Default gains `alpha = 0.30`, `beta = 0.05` (close to critically
+damped at 2 kHz update rate; rule of thumb is
+`beta = alpha^2 / (2 - alpha)`). Override via
+`CONFIG_ESP_FOC_PREDICTOR_ALPHA_X1000` /
+`CONFIG_ESP_FOC_PREDICTOR_BETA_X1000` (stored x1000 because Kconfig
+int does not take floats). The tracker degrades gracefully when the
+encoder hangs — the unit tests assert the predicted angle drift
+stays under 0.5 rad after 50 ms with no updates at 60 Hz electrical.
+
+When the ADC sample is older than one PWM period (drop / 50 kHz cap
+on plain ESP32 with PWM > 25 kHz), the ISR reuses the latest
+published value. The PI integrates one cycle of slightly stale
+current — way milder degradation than the legacy 2 kHz loop already
+lives with.
+
+Set `CONFIG_ESP_FOC_ISR_HOT_PATH=n` to fall back to the legacy 2.x
+task-based path. Useful while a sensorless observer config that has
+not been ported to the ISR path yet is in use.
+
+### Why not Plan #3 (offload sin/cos to the other core)?
+
+Investigated and dropped:
+
+* `esp_ipc_isr_call` exists in IDF v5.5 but on Xtensa (ESP32 /
+  ESP32-S3) the callback must be **assembly** with no C calls
+  allowed — the LUT-based `q16_sin/cos` in `iq31_sin/cos` cannot
+  run there.
+* The API offers only `_call` (busy-wait until the other core
+  starts) and `_call_blocking` (busy-wait until it finishes); no
+  asynchronous "done" callback back to the originating core, so
+  the desired `PWM ISR -> dispatch -> sincos done IRQ -> hot path`
+  pipeline cannot be assembled from the public IDF surface.
+* `q16_sin + q16_cos` together are a few hundred cycles (LUT 8192
+  + IQ31 conversions). The IPI round-trip would dwarf that.
+
+Documented for the record so we do not revisit it without new
+information.
+
 ## Alignment with natural-direction probe
 
 `esp_foc_align_axis()` parks the rotor at electrical 0, zeroes the

--- a/include/espFoC/drivers/current_sensor_interface.h
+++ b/include/espFoC/drivers/current_sensor_interface.h
@@ -32,4 +32,20 @@ struct esp_foc_isensor_s {
      * provide a no-op stub.
      */
     void (*set_filter_cutoff)(esp_foc_isensor_t *self, float fc_hz, float fs_hz);
+
+    /**
+     * @brief Wire i_alpha / i_beta sinks. After every full conversion
+     *        the driver applies offset + gain + Clarke to channels 0 / 1
+     *        (axis 0 U / V) and atomic-writes the result to the supplied
+     *        Q16 targets. The PWM ISR can then read i_alpha / i_beta
+     *        without going through fetch_isensors() (and without ever
+     *        blocking on critical sections).
+     *
+     * Pass NULL pointers to disable publishing. Drivers that do not run
+     * an ISR-side conversion (mocks, future hall-only) provide a no-op
+     * stub.
+     */
+    void (*set_publish_targets)(esp_foc_isensor_t *self,
+                                q16_t *i_alpha_target,
+                                q16_t *i_beta_target);
 };

--- a/include/espFoC/esp_foc_axis.h
+++ b/include/espFoC/esp_foc_axis.h
@@ -8,6 +8,7 @@
 #include "espFoC/esp_foc_units_q16.h"
 #include "espFoC/utils/pid_controller.h"
 #include "espFoC/utils/biquad_q16.h"
+#include "espFoC/utils/angle_predictor_q16.h"
 #include "espFoC/esp_foc_injection.h"
 #include "espFoC/drivers/inverter_interface.h"
 #include "espFoC/drivers/current_sensor_interface.h"
@@ -112,6 +113,20 @@ struct esp_foc_axis_s {
      * is current_filter_fs_hz_q16, captured at init. */
     q16_t current_filter_fc_hz_q16;
     q16_t current_filter_fs_hz_q16;
+
+#if defined(CONFIG_ESP_FOC_ISR_HOT_PATH)
+    /* Plan #2: full FOC pipeline runs inside the PWM ISR. The slow
+     * encoder is read from the outer task, fed into the alpha-beta
+     * predictor; the ISR queries predict() to get a fresh extrapolated
+     * electrical angle every PWM cycle. */
+    esp_foc_angle_predictor_q16_t angle_predictor;
+    /* ADC ISR atomic-writes Clarke output here; PWM ISR reads. Both
+     * are 32-bit aligned q16, single-instruction stores on Xtensa /
+     * RISC-V — no torn-read concern. The volatile keeps the compiler
+     * from caching the read across loop iterations. */
+    volatile q16_t latest_i_alpha;
+    volatile q16_t latest_i_beta;
+#endif
 
     esp_foc_injection_t injection;
 

--- a/include/espFoC/esp_foc_scope.h
+++ b/include/espFoC/esp_foc_scope.h
@@ -10,7 +10,17 @@
 #include "espFoC/utils/esp_foc_q16.h"
 
 void esp_foc_scope_initalize(void);
+
+/* Task-context push. Snapshots wired channels into the active write
+ * buffer; wakes the scope daemon via xTaskNotifyGive on rollover. */
 void esp_foc_scope_data_push(void);
+
+/* ISR-context push. Same wire format and ping-pong protocol but uses
+ * the FromISR notification variant so it is safe to call from inside
+ * an interrupt handler (e.g. the FOC hot path inside the PWM ISR).
+ * Stores raw Q16 values; float conversion is deferred to the daemon. */
+void esp_foc_scope_data_push_from_isr(void);
+
 int esp_foc_scope_add_channel(const q16_t *data_to_wire, int channel_number);
 
 void esp_foc_init_bus_callback(void);

--- a/include/espFoC/esp_foc_tuner.h
+++ b/include/espFoC/esp_foc_tuner.h
@@ -50,6 +50,7 @@ typedef enum {
     ESP_FOC_TUNER_PARAM_INT_LIM_Q16     = 0x0012, /* read q16 */
     ESP_FOC_TUNER_PARAM_V_MAX_Q16       = 0x0013, /* read q16 */
     ESP_FOC_TUNER_PARAM_I_FILTER_FC_Q16 = 0x0014, /* read q16 (Hz, current LPF) */
+    ESP_FOC_TUNER_PARAM_LOOP_FS_HZ_Q16  = 0x0015, /* read q16 (Hz, current PI sample rate) */
     ESP_FOC_TUNER_PARAM_AXIS_STATE      = 0x0040, /* read u8 bitmap */
     ESP_FOC_TUNER_PARAM_AXIS_LAST_ERR   = 0x0041, /* read i8 (esp_foc_err_t) */
     ESP_FOC_TUNER_PARAM_NVS_PRESENT     = 0x0042, /* read u8 (0/1) */

--- a/include/espFoC/utils/angle_predictor_q16.h
+++ b/include/espFoC/utils/angle_predictor_q16.h
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+/**
+ * @file angle_predictor_q16.h
+ * @brief Alpha-beta tracker for the electrical rotor angle in Q16.16.
+ *
+ * Bridges a slow encoder reading (e.g. AS5600 over I2C, ~2 kHz hard
+ * cap) and a fast inner control loop (e.g. the FOC PI inside the PWM
+ * ISR at 40 kHz). The outer task folds new measurements into the
+ * tracker; the ISR queries `predict()` every PWM cycle to get a fresh
+ * extrapolated electrical angle, no I2C blocking required.
+ *
+ * The math is the textbook 2nd-order alpha-beta filter (a constant-gain
+ * Kalman simplification used for radar and motor tracking):
+ *
+ *     predict(t_now):
+ *         dt = t_now - t_last
+ *         theta_pred = wrap_2pi(theta_est + omega_est * dt)
+ *         return theta_pred                      (state untouched)
+ *
+ *     update(theta_meas, t_meas):
+ *         dt = t_meas - t_last
+ *         theta_pred = wrap_2pi(theta_est + omega_est * dt)
+ *         err        = wrap_pi(theta_meas - theta_pred)   in (-pi, +pi]
+ *         theta_est  = wrap_2pi(theta_pred + alpha * err)
+ *         omega_est += (beta / dt) * err
+ *         t_last     = t_meas
+ *
+ * Critical-damping rule of thumb: beta = alpha^2 / (2 - alpha). The
+ * defaults exposed via Kconfig (alpha = 0.30, beta = 0.05) sit close
+ * to that for a 2 kHz update rate.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "espFoC/utils/esp_foc_q16.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    q16_t alpha;
+    q16_t beta;
+    q16_t theta_est;     /* electrical angle, [0, 2*pi) */
+    q16_t omega_est;     /* electrical speed, rad/s */
+    uint64_t t_last_us;  /* esp_timer monotonic, set on init / update */
+    bool initialised;
+} esp_foc_angle_predictor_q16_t;
+
+/**
+ * @brief Reset state and program the gains. Sets t_last to t_now_us
+ *        so the first predict() returns whatever theta_est was
+ *        initialised to without an enormous extrapolation step.
+ *
+ * @param alpha measurement gain in (0, 1]
+ * @param beta  velocity gain (typ alpha^2 / (2 - alpha))
+ */
+void esp_foc_angle_predictor_init_q16(esp_foc_angle_predictor_q16_t *p,
+                                      float alpha, float beta,
+                                      uint64_t t_now_us);
+
+/**
+ * @brief Reprogram the gains without touching state. Safe to call
+ *        between updates; new gains take effect on the next update().
+ */
+void esp_foc_angle_predictor_set_gains_q16(esp_foc_angle_predictor_q16_t *p,
+                                           float alpha, float beta);
+
+/**
+ * @brief Outer task: fold a fresh sensor reading into the tracker.
+ *        theta_meas is the electrical angle in radians (q16), expected
+ *        in [0, 2*pi). The residual is wrapped to (-pi, +pi] so the
+ *        2*pi boundary never produces a huge omega step.
+ *
+ *        First call after init seeds theta_est = theta_meas and leaves
+ *        omega_est at zero — no spurious velocity from the inaugural dt.
+ */
+void esp_foc_angle_predictor_update_q16(esp_foc_angle_predictor_q16_t *p,
+                                        q16_t theta_meas,
+                                        uint64_t t_meas_us);
+
+/**
+ * @brief PWM ISR: extrapolate to t_now. Cheap (one mul, one add, one
+ *        wrap). Does NOT mutate state — concurrent calls from the
+ *        outer task and the ISR are safe as long as update() is
+ *        bracketed by a critical section the ISR also honours.
+ */
+q16_t esp_foc_angle_predictor_predict_q16(
+    const esp_foc_angle_predictor_q16_t *p,
+    uint64_t t_now_us);
+
+/**
+ * @brief Convenience accessor: latest electrical speed estimate
+ *        (rad/s, q16). Read-only; safe from any context.
+ */
+static inline q16_t esp_foc_angle_predictor_speed_q16(
+    const esp_foc_angle_predictor_q16_t *p)
+{
+    return p->omega_est;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/drivers/current_sensor_adc.c
+++ b/source/drivers/current_sensor_adc.c
@@ -28,6 +28,7 @@
 #include <math.h>
 #include "espFoC/utils/esp_foc_q16.h"
 #include "espFoC/utils/biquad_q16.h"
+#include "espFoC/utils/foc_math_q16.h"
 #include "espFoC/driver_iq31_local.h"
 #include "espFoC/current_sensor_adc.h"
 #include "hal/adc_hal.h"
@@ -58,6 +59,12 @@ typedef struct {
     int32_t filtered_count[4];
     esp_foc_biquad_q16_t bq[4];
     float offsets[4];
+    /* Optional Clarke publish targets. When both are non-NULL the ADC
+     * ISR computes (offset, gain, Clarke) on channels 0/1 right after
+     * the biquad and atomic-writes the result. The PWM ISR can then
+     * read i_alpha / i_beta directly without a fetch_isensors() call. */
+    volatile q16_t *publish_alpha;
+    volatile q16_t *publish_beta;
     esp_foc_isensor_t interface;
     int number_of_channels;
     isensor_callback_t callback;
@@ -93,6 +100,34 @@ DRAM_ATTR static isensor_adc_t isensor_adc;
 static bool adc_initialized = false;
 static const float adc_to_volts = ((3.1f)/ 4096.0f);
 
+/* Apply offset + gain + Clarke on channels 0/1 and atomic-write
+ * (i_alpha, i_beta) into the publish targets. Inlined into the ISR
+ * for the new ISR-driven hot path to skip; called only when both
+ * targets are wired. Channels 2/3 (axis 1) are not handled here —
+ * Plan #2 is single-axis for now. */
+static inline void adc_publish_alpha_beta(isensor_adc_t *obj)
+{
+    const int32_t adc_rng = 2048;
+    int32_t d0 = obj->filtered_count[0] - (int32_t)lroundf(obj->offsets[0]);
+    int32_t d1 = obj->filtered_count[1] - (int32_t)lroundf(obj->offsets[1]);
+    d0 = esp_foc_clamp_int32(d0, -adc_rng, adc_rng);
+    d1 = esp_foc_clamp_int32(d1, -adc_rng, adc_rng);
+    q16_t iu = q16_mul(esp_foc_q16_from_adc_diff_clamped(d0, adc_rng),
+                       obj->adc_to_current_scale_q16);
+    q16_t iv = q16_mul(esp_foc_q16_from_adc_diff_clamped(d1, adc_rng),
+                       obj->adc_to_current_scale_q16);
+    /* Three-phase KCL gives iw, then the standard Clarke (with the
+     * codebase's q16_clarke helper which expects u/v/w). */
+    q16_t iw = q16_sub(0, q16_add(iu, iv));
+    q16_t alpha, beta;
+    q16_clarke(iu, iv, iw, &alpha, &beta);
+    /* Single 32-bit aligned writes; both Xtensa and RISC-V deliver
+     * these as one store, so the PWM ISR can read either field
+     * without a torn-read concern. */
+    *obj->publish_alpha = alpha;
+    *obj->publish_beta  = beta;
+}
+
 static bool isensor_adc_done_callback(adc_continuous_handle_t handle, const adc_continuous_evt_data_t *edata, void *user_data)
 {
     adc_hal_digi_enable(false);
@@ -113,6 +148,10 @@ static bool isensor_adc_done_callback(adc_continuous_handle_t handle, const adc_
                                             (q16_t)(raw << 16));
         isensor->filtered_count[i] = y >> 16;
         p++;
+    }
+
+    if(isensor->publish_alpha != NULL && isensor->publish_beta != NULL) {
+        adc_publish_alpha_beta(isensor);
     }
 
     if(isensor->callback != NULL) {
@@ -274,6 +313,19 @@ static void set_filter_cutoff(esp_foc_isensor_t *self, float fc_hz, float fs_hz)
     esp_foc_critical_leave();
 }
 
+static void set_publish_targets(esp_foc_isensor_t *self,
+                                q16_t *i_alpha_target,
+                                q16_t *i_beta_target)
+{
+    isensor_adc_t *obj =
+        __containerof(self, isensor_adc_t, interface);
+
+    esp_foc_critical_enter();
+    obj->publish_alpha = (volatile q16_t *)i_alpha_target;
+    obj->publish_beta  = (volatile q16_t *)i_beta_target;
+    esp_foc_critical_leave();
+}
+
 
 esp_foc_isensor_t *isensor_adc_new(esp_foc_isensor_adc_config_t *config)
 {
@@ -290,6 +342,9 @@ esp_foc_isensor_t *isensor_adc_new(esp_foc_isensor_adc_config_t *config)
     isensor_adc.interface.calibrate_isensors = calibrate_isensors;
     isensor_adc.interface.set_isensor_callback = set_callback;
     isensor_adc.interface.set_filter_cutoff = set_filter_cutoff;
+    isensor_adc.interface.set_publish_targets = set_publish_targets;
+    isensor_adc.publish_alpha = NULL;
+    isensor_adc.publish_beta  = NULL;
     /* Default to bypass so the driver works correctly even if the
      * caller (axis init / tuner) never invokes set_filter_cutoff. */
     for (int i = 0; i < 4; ++i) {

--- a/source/drivers/current_sensor_adc_one_shot.c
+++ b/source/drivers/current_sensor_adc_one_shot.c
@@ -28,6 +28,7 @@
 #include <sdkconfig.h>
 #include "espFoC/utils/esp_foc_q16.h"
 #include "espFoC/utils/biquad_q16.h"
+#include "espFoC/utils/foc_math_q16.h"
 #include "espFoC/driver_iq31_local.h"
 #include "espFoC/current_sensor_adc_one_shot.h"
 #include "hal/adc_hal.h"
@@ -57,6 +58,10 @@ typedef struct {
     int32_t filtered_count[4];
     esp_foc_biquad_q16_t bq[4];
     float offsets[4];
+    /* Optional Clarke publish targets — see current_sensor_adc.c for
+     * the same plumbing on the continuous driver. */
+    volatile q16_t *publish_alpha;
+    volatile q16_t *publish_beta;
     esp_foc_isensor_t interface;
 
     int number_of_channels;
@@ -96,6 +101,24 @@ static adc_oneshot_hal_cfg_t hal_cfg = {
 
 static void oneshot_adc_start_sample(isensor_adc_t *isensor, adc_channel_t channel, adc_unit_t unit);
 
+static inline void adc_publish_alpha_beta(isensor_adc_t *obj)
+{
+    const int32_t adc_rng = 2048;
+    int32_t d0 = obj->filtered_count[0] - (int32_t)lroundf(obj->offsets[0]);
+    int32_t d1 = obj->filtered_count[1] - (int32_t)lroundf(obj->offsets[1]);
+    d0 = esp_foc_clamp_int32(d0, -adc_rng, adc_rng);
+    d1 = esp_foc_clamp_int32(d1, -adc_rng, adc_rng);
+    q16_t iu = q16_mul(esp_foc_q16_from_adc_diff_clamped(d0, adc_rng),
+                       obj->adc_to_current_scale_q16);
+    q16_t iv = q16_mul(esp_foc_q16_from_adc_diff_clamped(d1, adc_rng),
+                       obj->adc_to_current_scale_q16);
+    q16_t iw = q16_sub(0, q16_add(iu, iv));
+    q16_t alpha, beta;
+    q16_clarke(iu, iv, iw, &alpha, &beta);
+    *obj->publish_alpha = alpha;
+    *obj->publish_beta  = beta;
+}
+
 static void isensor_adc_isr(void *arg)
 {
     isensor_adc_t * isensor = (isensor_adc_t *)arg;
@@ -128,6 +151,9 @@ static void isensor_adc_isr(void *arg)
             isensor->number_of_conversions = 0;
             adc_oneshot_ll_clear_event(event);
             adc_oneshot_ll_disable_all_unit();
+            if(isensor->publish_alpha != NULL && isensor->publish_beta != NULL) {
+                adc_publish_alpha_beta(isensor);
+            }
             if(isensor->callback) {
                 isensor->callback(isensor->user_data);
             }
@@ -336,6 +362,19 @@ static void set_filter_cutoff(esp_foc_isensor_t *self, float fc_hz, float fs_hz)
     esp_foc_critical_leave();
 }
 
+static void set_publish_targets(esp_foc_isensor_t *self,
+                                q16_t *i_alpha_target,
+                                q16_t *i_beta_target)
+{
+    isensor_adc_t *obj =
+        __containerof(self, isensor_adc_t, interface);
+
+    esp_foc_critical_enter();
+    obj->publish_alpha = (volatile q16_t *)i_alpha_target;
+    obj->publish_beta  = (volatile q16_t *)i_beta_target;
+    esp_foc_critical_leave();
+}
+
 static void set_to_zero(esp_foc_rotor_sensor_t *self)
 {
     isensor_adc_t *obj = __containerof(self, isensor_adc_t, encoder_interface);
@@ -421,6 +460,9 @@ esp_foc_isensor_t *isensor_adc_oneshot_new(esp_foc_isensor_adc_oneshot_config_t 
     isensor_adc.interface.calibrate_isensors = calibrate_isensors;
     isensor_adc.interface.set_isensor_callback = set_callback;
     isensor_adc.interface.set_filter_cutoff = set_filter_cutoff;
+    isensor_adc.interface.set_publish_targets = set_publish_targets;
+    isensor_adc.publish_alpha = NULL;
+    isensor_adc.publish_beta  = NULL;
     isensor_adc.number_of_channels = config->number_of_channels;
     /* Default to bypass on every channel; axis init dials a real
      * cutoff in via set_filter_cutoff. */

--- a/source/motor_control/control_strategy/esp_foc_control_current_mode_sensored.c
+++ b/source/motor_control/control_strategy/esp_foc_control_current_mode_sensored.c
@@ -24,10 +24,235 @@
 
 #include <stdbool.h>
 #include "esp_log.h"
+#include "esp_attr.h"
 #include "espFoC/esp_foc.h"
 #include "espFoC/utils/foc_math_q16.h"
 
 static const char * tag = "ESP_FOC_CONTROL";
+
+#if defined(CONFIG_ESP_FOC_ISR_HOT_PATH)
+
+/* ============================================================
+ *  Plan #2: full FOC pipeline runs inside the PWM ISR.
+ *
+ *  The ADC ISR has already published latest_i_alpha / latest_i_beta
+ *  on the axis. The angle predictor lives on the axis too; the outer
+ *  task feeds it with fresh encoder readings and we extrapolate
+ *  every PWM cycle.
+ *
+ *  set_voltages() down to mcpwm_comparator_set_compare_value() is
+ *  IRAM-attributed in IDF v5.5; the rest of the helpers used here
+ *  (q16_park, q16_sin/cos LUT, esp_foc_modulate_dq_voltage,
+ *  esp_foc_pid_update) are pure Q16 / IRAM-friendly arithmetic.
+ *  Everything in this ISR has to either live in IRAM or be cache-
+ *  warm; the IRAM_ATTR on the function itself plus the LUT pinning
+ *  in esp_foc_iq31.c covers that.
+ * ============================================================ */
+
+IRAM_ATTR static void foc_hot_isr(void *data)
+{
+    esp_foc_axis_t *axis = (esp_foc_axis_t *)data;
+
+    /* 1) Snapshot the latest Clarke-published currents. Two volatile
+     *    q16 reads — single-instruction loads, no torn read. */
+    q16_t i_alpha = axis->latest_i_alpha;
+    q16_t i_beta  = axis->latest_i_beta;
+
+    /* 2) Predict electrical angle for "now". This call only touches
+     *    the predictor's read-only fields; the outer task wraps
+     *    update() in a critical section the ISR also honours, so the
+     *    snapshot here is consistent. */
+    uint64_t now_us = esp_foc_now_useconds();
+    q16_t theta_e = esp_foc_angle_predictor_predict_q16(
+                        &axis->angle_predictor, now_us);
+
+    /* 3) sin / cos. Backed by the IQ31 LUT in iram, no flash hit. */
+    q16_t e_sin = q16_sin(theta_e);
+    q16_t e_cos = q16_cos(theta_e);
+
+    /* 4) Park transform. */
+    q16_t i_d, i_q;
+    q16_park(e_sin, e_cos, i_alpha, i_beta, &i_d, &i_q);
+
+    /* 5) Publish for scope / status. */
+    axis->i_alpha.raw = i_alpha;
+    axis->i_beta.raw  = i_beta;
+    axis->i_d.raw = i_d;
+    axis->i_q.raw = i_q;
+    axis->rotor_elec_angle = theta_e;
+
+    /* 6) Current PI (or override / open-loop voltage). */
+    q16_t u_d, u_q;
+
+#if defined(CONFIG_ESP_FOC_TUNER_ENABLE)
+    if (axis->tuner_override.active) {
+        /* Tuner has the steering wheel — bypass the PI completely. */
+        u_d = axis->tuner_override.target_ud;
+        u_q = axis->tuner_override.target_uq;
+    } else
+#endif
+    if (axis->skip_torque_control) {
+        /* Open-loop voltage mode: take the operator's u_d / u_q
+         * straight through, no integration. */
+        u_d = axis->target_u_d.raw;
+        u_q = axis->target_u_q.raw;
+    } else {
+#if defined(CONFIG_ESP_FOC_INJECTION_ENABLE)
+        q16_t iq_ref = esp_foc_injection_apply_q16(&axis->injection,
+                                                   axis->target_i_q.raw);
+#else
+        q16_t iq_ref = axis->target_i_q.raw;
+#endif
+        u_q = esp_foc_pid_update(&axis->torque_controller[0],
+                                 iq_ref, i_q);
+        u_d = esp_foc_pid_update(&axis->torque_controller[1],
+                                 axis->target_i_d.raw, i_d);
+        /* User-provided feed-forward gets stacked on top of the PI
+         * output (matches the legacy semantics 1:1). */
+        u_q = q16_add(u_q, axis->target_u_q.raw);
+        u_d = q16_add(u_d, axis->target_u_d.raw);
+    }
+    axis->u_q.raw = u_q;
+    axis->u_d.raw = u_d;
+
+    /* 7) Inverse Park + SVPWM in one shot. */
+    q16_t u_alpha, u_beta, u_u, u_v, u_w;
+    esp_foc_modulate_dq_voltage(e_sin, e_cos, u_d, u_q,
+                                &u_alpha, &u_beta,
+                                &u_u, &u_v, &u_w,
+                                axis->max_voltage,
+                                axis->dc_link_to_normalized);
+    axis->u_alpha.raw = u_alpha;
+    axis->u_beta.raw  = u_beta;
+    axis->u_u.raw = u_u;
+    axis->u_v.raw = u_v;
+    axis->u_w.raw = u_w;
+
+    /* 8) Push duties to the inverter. mcpwm_comparator_set_compare_value
+     *    is IRAM-safe in IDF v5.5. */
+    axis->inverter_driver->set_voltages(axis->inverter_driver, u_u, u_v, u_w);
+
+    /* 9) Optionally snapshot every wired channel into the scope ring.
+     *    The from_isr variant uses xTaskNotifyGiveFromISR on rollover. */
+#if defined(CONFIG_ESP_FOC_SCOPE)
+    esp_foc_scope_data_push_from_isr();
+#endif
+
+    /* 10) Downsample counter. When it expires, wake the outer task
+     *     so it reads the encoder, updates the predictor and dispatches
+     *     the user regulation callback. */
+    if (axis->downsampling_low_speed) {
+        axis->downsampling_low_speed--;
+        if (!axis->downsampling_low_speed) {
+            axis->downsampling_low_speed = ESP_FOC_LOW_SPEED_DOWNSAMPLING;
+            if (axis->low_speed_ev != NULL) {
+                esp_foc_send_notification_from_isr(axis->low_speed_ev);
+            }
+        }
+    }
+}
+
+/* The ADC publish path now lives inside the ADC driver itself (Clarke
+ * + atomic write to axis->latest_i_alpha/beta). No "high-speed callback"
+ * is needed any more, but the field stays wired to a no-op so existing
+ * isensor implementations that always invoke it stay happy. */
+void do_current_mode_sensored_high_speed_loop(void *arg)
+{
+    (void)arg;
+}
+
+void do_current_mode_sensored_low_speed_loop(void *arg)
+{
+    esp_foc_axis_t *axis = (esp_foc_axis_t *)arg;
+
+    axis->low_speed_ev = esp_foc_get_event_handle();
+    axis->downsampling_low_speed = ESP_FOC_LOW_SPEED_DOWNSAMPLING;
+
+    ESP_LOGI(tag, "Starting sensored FOC outer loop (ISR hot path)");
+
+    /* Cold-start: take one encoder reading before the ISR starts so
+     * the predictor seeds with a real angle (otherwise the first
+     * 25 us of PWM would extrapolate from theta_est = 0). */
+    q16_t ticks0 = axis->rotor_sensor_driver->read_counts(axis->rotor_sensor_driver);
+    axis->rotor_shaft_ticks = ticks0;
+    axis->rotor_position = q16_mul(ticks0, axis->natural_direction);
+    axis->rotor_position_prev = axis->rotor_position;
+    axis->current_speed = 0;
+    {
+        int pp = axis->motor_pole_pairs;
+        int64_t et = (int64_t)axis->rotor_position * (int64_t)pp;
+        q16_t elec_frac = (q16_t)(et % (int64_t)Q16_ONE);
+        if (elec_frac < 0) {
+            elec_frac = (q16_t)((int64_t)elec_frac + (int64_t)Q16_ONE);
+        }
+        q16_t theta_meas = q16_mul(elec_frac, Q16_TWO_PI);
+        esp_foc_critical_enter();
+        esp_foc_angle_predictor_update_q16(&axis->angle_predictor,
+                                            theta_meas,
+                                            esp_foc_now_useconds());
+        esp_foc_critical_leave();
+    }
+
+    /* Hand the ISR over to the inverter driver only AFTER the
+     * predictor has a real seed — otherwise the first PWM tick would
+     * fire set_voltages() with garbage angles. */
+    axis->inverter_driver->set_inverter_callback(axis->inverter_driver,
+                                                 foc_hot_isr,
+                                                 axis);
+
+    while (1) {
+        esp_foc_wait_notifier();
+
+#ifdef CONFIG_ESP_FOC_DEBUG_CORE_TIMING
+        esp_foc_debug_pin_set();
+#endif
+
+        /* 1) Read the slow encoder. May block on I2C / SPI for ~125 us. */
+        q16_t ticks = axis->rotor_sensor_driver->read_counts(axis->rotor_sensor_driver);
+        axis->rotor_shaft_ticks = ticks;
+        q16_t pos = q16_mul(ticks, axis->natural_direction);
+        axis->rotor_position = pos;
+
+        /* 2) Mechanical angle * pp -> normalised electrical angle. */
+        int pp = axis->motor_pole_pairs;
+        int64_t et = (int64_t)pos * (int64_t)pp;
+        q16_t elec_frac = (q16_t)(et % (int64_t)Q16_ONE);
+        if (elec_frac < 0) {
+            elec_frac = (q16_t)((int64_t)elec_frac + (int64_t)Q16_ONE);
+        }
+        q16_t theta_meas = q16_mul(elec_frac, Q16_TWO_PI);
+
+        /* 3) Fold into the alpha-beta tracker under critical section
+         *    so the PWM ISR cannot land mid-update and read a torn
+         *    {theta_est, omega_est, t_last} triple. */
+        uint64_t now_us = esp_foc_now_useconds();
+        esp_foc_critical_enter();
+        esp_foc_angle_predictor_update_q16(&axis->angle_predictor,
+                                            theta_meas, now_us);
+        esp_foc_critical_leave();
+
+        /* 4) Velocity smoothing: the outer loop is the rate at which
+         *    rotor_position actually changes, so the biquad sees a
+         *    consistent dt. */
+        q16_t dtheta = q16_sub(pos, axis->rotor_position_prev);
+        q16_t raw_speed = q16_mul(dtheta,
+                                   axis->torque_controller[0].inv_dt);
+        axis->current_speed = esp_foc_biquad_q16_update(
+                                  &axis->velocity_filter, raw_speed);
+        axis->rotor_position_prev = pos;
+
+        /* 5) Wake the regulator task so the user callback can refresh
+         *    target_i_d / target_i_q / target_u_d / target_u_q before
+         *    the next batch of PWM cycles. */
+        esp_foc_send_notification(axis->regulator_ev);
+
+#ifdef CONFIG_ESP_FOC_DEBUG_CORE_TIMING
+        esp_foc_debug_pin_clear();
+#endif
+    }
+}
+
+#else /* CONFIG_ESP_FOC_ISR_HOT_PATH not set — legacy 2.x task path */
 
 static void inverter_isr(void *data)
 {
@@ -216,3 +441,4 @@ void do_current_mode_sensored_low_speed_loop(void *arg)
     }
 }
 
+#endif /* CONFIG_ESP_FOC_ISR_HOT_PATH */

--- a/source/motor_control/esp_foc_angle_predictor.c
+++ b/source/motor_control/esp_foc_angle_predictor.c
@@ -1,0 +1,160 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Felipe Neves
+ */
+
+#include "espFoC/utils/angle_predictor_q16.h"
+#include "espFoC/utils/foc_math_q16.h"
+
+/* Q16 representation of pi. Q16_TWO_PI is exposed in esp_foc_q16.h
+ * (411775); pi sits at half that. Defined locally so the predictor
+ * does not pollute the public q16 header with a single-purpose const. */
+#define Q16_PI ((q16_t)(Q16_TWO_PI / 2))
+
+/* Wrap a signed angle delta to (-pi, +pi]. Used on the residual so
+ * the 0 / 2*pi seam never produces a 2*pi-sized error. */
+static inline q16_t wrap_pi_q16(q16_t a)
+{
+    while (a > Q16_PI) {
+        a = (q16_t)((int32_t)a - (int32_t)Q16_TWO_PI);
+    }
+    while (a <= -Q16_PI) {
+        a = (q16_t)((int32_t)a + (int32_t)Q16_TWO_PI);
+    }
+    return a;
+}
+
+/* Convert a microsecond delta into Q16 seconds. Caps at INT32_MAX
+ * which corresponds to ~32k seconds — the predictor is always going
+ * to be called way more often than that. */
+static inline q16_t dt_q16_from_us(uint64_t us)
+{
+    int64_t raw = ((int64_t)us * (int64_t)Q16_ONE + 500000LL) / 1000000LL;
+    if (raw > (int64_t)INT32_MAX) {
+        return (q16_t)INT32_MAX;
+    }
+    return (q16_t)raw;
+}
+
+void esp_foc_angle_predictor_init_q16(esp_foc_angle_predictor_q16_t *p,
+                                      float alpha, float beta,
+                                      uint64_t t_now_us)
+{
+    if (p == NULL) {
+        return;
+    }
+    if (alpha < 0.0f) {
+        alpha = 0.0f;
+    } else if (alpha > 1.0f) {
+        alpha = 1.0f;
+    }
+    if (beta < 0.0f) {
+        beta = 0.0f;
+    } else if (beta > 1.0f) {
+        beta = 1.0f;
+    }
+    p->alpha = q16_from_float(alpha);
+    p->beta  = q16_from_float(beta);
+    p->theta_est = 0;
+    p->omega_est = 0;
+    p->t_last_us = t_now_us;
+    p->initialised = false;
+}
+
+void esp_foc_angle_predictor_set_gains_q16(esp_foc_angle_predictor_q16_t *p,
+                                           float alpha, float beta)
+{
+    if (p == NULL) {
+        return;
+    }
+    if (alpha < 0.0f) {
+        alpha = 0.0f;
+    } else if (alpha > 1.0f) {
+        alpha = 1.0f;
+    }
+    if (beta < 0.0f) {
+        beta = 0.0f;
+    } else if (beta > 1.0f) {
+        beta = 1.0f;
+    }
+    p->alpha = q16_from_float(alpha);
+    p->beta  = q16_from_float(beta);
+}
+
+void esp_foc_angle_predictor_update_q16(esp_foc_angle_predictor_q16_t *p,
+                                        q16_t theta_meas,
+                                        uint64_t t_meas_us)
+{
+    if (p == NULL) {
+        return;
+    }
+
+    /* Make sure theta_meas is normalised so the residual wrap below
+     * is honest about its [0, 2*pi) input. Cheap if it already is. */
+    theta_meas = q16_normalize_angle_rad(theta_meas);
+
+    if (!p->initialised) {
+        /* First measurement seeds the state: jump theta_est to the
+         * observed angle and leave omega_est at zero. The next call
+         * gets a real dt and starts tracking. */
+        p->theta_est = theta_meas;
+        p->omega_est = 0;
+        p->t_last_us = t_meas_us;
+        p->initialised = true;
+        return;
+    }
+
+    uint64_t dt_us = (t_meas_us > p->t_last_us)
+                       ? (t_meas_us - p->t_last_us)
+                       : 0u;
+    if (dt_us == 0u) {
+        /* No time advanced — nothing meaningful to integrate. Update
+         * theta_est anyway so a paused-then-resumed encoder does not
+         * lose alignment. */
+        p->theta_est = theta_meas;
+        p->t_last_us = t_meas_us;
+        return;
+    }
+
+    q16_t dt = dt_q16_from_us(dt_us);
+    /* theta_pred = wrap(theta_est + omega_est * dt) */
+    q16_t theta_pred = q16_normalize_angle_rad(
+        q16_add(p->theta_est, q16_mul(p->omega_est, dt)));
+    q16_t err = wrap_pi_q16(q16_sub(theta_meas, theta_pred));
+
+    p->theta_est = q16_normalize_angle_rad(
+        q16_add(theta_pred, q16_mul(p->alpha, err)));
+
+    /* omega_est += (beta / dt) * err. Done as (beta * err) / dt to
+     * stay inside Q16's int32 range; intermediate uses int64. */
+    if (dt > 0) {
+        int64_t num = (int64_t)p->beta * (int64_t)err; /* Q32 */
+        /* (Q32 / Q16) = Q16 with a shift */
+        int64_t step_q16 = (num / (int64_t)dt);
+        int64_t new_omega = (int64_t)p->omega_est + step_q16;
+        if (new_omega > (int64_t)INT32_MAX) {
+            new_omega = INT32_MAX;
+        } else if (new_omega < (int64_t)INT32_MIN) {
+            new_omega = INT32_MIN;
+        }
+        p->omega_est = (q16_t)new_omega;
+    }
+
+    p->t_last_us = t_meas_us;
+}
+
+q16_t esp_foc_angle_predictor_predict_q16(
+    const esp_foc_angle_predictor_q16_t *p,
+    uint64_t t_now_us)
+{
+    if (p == NULL || !p->initialised) {
+        return 0;
+    }
+    uint64_t dt_us = (t_now_us > p->t_last_us)
+                       ? (t_now_us - p->t_last_us)
+                       : 0u;
+    q16_t dt = dt_q16_from_us(dt_us);
+    return q16_normalize_angle_rad(
+        q16_add(p->theta_est, q16_mul(p->omega_est, dt)));
+}

--- a/source/motor_control/esp_foc_axis_tuning.c
+++ b/source/motor_control/esp_foc_axis_tuning.c
@@ -37,14 +37,23 @@ esp_foc_err_t esp_foc_axis_retune_current_pi_q16(
         return ESP_FOC_ERR_INVALID_ARG;
     }
 
-    int pwm_rate_hz = axis->inverter_driver->get_inverter_pwm_rate(axis->inverter_driver);
-    if (pwm_rate_hz <= 0) {
-        return ESP_FOC_ERR_INVALID_ARG;
+    /* Pull the loop period straight from the PID itself — that field
+     * is set in esp_foc_initialize_axis() to the actual rate the
+     * controller fires at (PWM period under ISR_HOT_PATH, or
+     * pwm_period * downsampling under the legacy task path). Using
+     * the PWM rate * a hardcoded DOWNSAMPLING constant here is wrong
+     * the moment those two stop matching — exactly what the ISR hot
+     * path did, leaving the MPZ designer convinced fs = 2 kHz and
+     * rejecting any bandwidth above 1 kHz with OUT_OF_RANGE. */
+    q16_t loop_dt_q16 = axis->torque_controller[0].dt;
+    if (loop_dt_q16 <= 0) {
+        return ESP_FOC_ERR_TIMESTEP_TOO_SMALL;
     }
-
-    /* loop_ts_us = 1e6 * DOWNSAMPLING / pwm_rate_hz */
-    uint32_t loop_ts_us = (uint32_t)((1000000ULL * (uint64_t)ESP_FOC_LOW_SPEED_DOWNSAMPLING)
-                                     / (uint64_t)pwm_rate_hz);
+    /* loop_ts_us = round(loop_dt_q16 * 1e6 / Q16_ONE), int64 to keep
+     * things honest at small dt values (25 us = 1638 in Q16). */
+    uint32_t loop_ts_us = (uint32_t)(((int64_t)loop_dt_q16 * 1000000LL
+                                      + (int64_t)Q16_ONE / 2)
+                                     / (int64_t)Q16_ONE);
     if (loop_ts_us == 0) {
         return ESP_FOC_ERR_TIMESTEP_TOO_SMALL;
     }

--- a/source/motor_control/esp_foc_core.c
+++ b/source/motor_control/esp_foc_core.c
@@ -26,6 +26,9 @@
 #include "esp_log.h"
 #include "espFoC/esp_foc.h"
 #include "espFoC/esp_foc_calibration.h"
+#if defined(CONFIG_ESP_FOC_ISR_HOT_PATH)
+#include "espFoC/utils/angle_predictor_q16.h"
+#endif
 
 #if defined(ESP_FOC_AUTOGEN_GAINS_AVAILABLE)
 #include "esp_foc_autotuned_gains.h"
@@ -204,6 +207,28 @@ esp_foc_err_t esp_foc_initialize_axis(esp_foc_axis_t *axis,
     }
     axis->current_filter_fc_hz_q16 = q16_from_float(current_filter_fc_hz);
     axis->current_filter_fs_hz_q16 = q16_from_float(loop_fs_hz);
+
+#if defined(CONFIG_ESP_FOC_ISR_HOT_PATH)
+    axis->latest_i_alpha = 0;
+    axis->latest_i_beta = 0;
+    /* Predictor starts uninitialised; the first outer-loop tick after
+     * alignment will seed it from the live encoder reading. Gains
+     * come from Kconfig (stored x1000 to dodge float). */
+    float pred_alpha = (float)CONFIG_ESP_FOC_PREDICTOR_ALPHA_X1000 / 1000.0f;
+    float pred_beta = (float)CONFIG_ESP_FOC_PREDICTOR_BETA_X1000 / 1000.0f;
+    esp_foc_angle_predictor_init_q16(&axis->angle_predictor,
+                                     pred_alpha, pred_beta,
+                                     esp_foc_now_useconds());
+    /* Wire the ADC ISR's Clarke-publish path straight into the axis
+     * fields the PWM ISR will read. NULL targets disable publishing,
+     * so this is also the opt-in point for the new pipeline. */
+    if (isensor != NULL && axis->isensor_driver->set_publish_targets != NULL) {
+        axis->isensor_driver->set_publish_targets(
+            axis->isensor_driver,
+            (q16_t *)&axis->latest_i_alpha,
+            (q16_t *)&axis->latest_i_beta);
+    }
+#endif
 
     axis->motor_pole_pairs = settings.motor_pole_pairs;
 

--- a/source/motor_control/esp_foc_core.c
+++ b/source/motor_control/esp_foc_core.c
@@ -156,8 +156,18 @@ esp_foc_err_t esp_foc_initialize_axis(esp_foc_axis_t *axis,
 
     /* Both torque controllers (Q-axis and D-axis) share the same dt and
      * the same starting gains; the runtime tuner can rewrite either one
-     * later with esp_foc_axis_set_current_pi_gains_q16(). */
+     * later with esp_foc_axis_set_current_pi_gains_q16().
+     *
+     * Under ISR_HOT_PATH the PI fires every PWM period; otherwise the
+     * legacy task path runs at pwm_rate / downsampling. The PID dt
+     * (and the autotuner fs in CMake) must agree — Kconfig defaults
+     * AUTOGEN_DECIMATION to 1 when ISR_HOT_PATH is on so the
+     * generated Kp / Ki land at the same fs the loop will run at. */
+#if defined(CONFIG_ESP_FOC_ISR_HOT_PATH)
+    float loop_dt_s = dt_f;
+#else
     float loop_dt_s = dt_f * (float)ESP_FOC_LOW_SPEED_DOWNSAMPLING;
+#endif
     float loop_fs_hz = (loop_dt_s > 1e-9f) ? (1.0f / loop_dt_s) : 0.0f;
     q16_t loop_dt = q16_from_float(loop_dt_s);
     q16_t loop_inv_dt = q16_from_float(loop_fs_hz);

--- a/source/motor_control/esp_foc_scope.c
+++ b/source/motor_control/esp_foc_scope.c
@@ -32,7 +32,10 @@
 const char *TAG = "ESP_FOC_SCOPE";
 
 struct scope_frame {
-    float data[CONFIG_ESP_FOC_SCOPE_NUM_CHANNELS];
+    /* Buffered as raw Q16 so the data_push path stays float-free —
+     * Xtensa FPU context save in an ISR is non-trivial and the
+     * conversion is cheap to defer to the daemon thread anyway. */
+    q16_t data[CONFIG_ESP_FOC_SCOPE_NUM_CHANNELS];
 };
 
 static uint32_t used_channels = 0;
@@ -80,14 +83,16 @@ static void esp_foc_scope_daemon_thread(void *arg)
         if(used_channels != 0) {
             for(int i = 0; i < CONFIG_ESP_FOC_SCOPE_NUM_CHANNELS; i++) {
                 if(used_channels & (1 << i)) {
-                    idx += sprintf(&out_buf[idx],"%f,",next_sample->data[i]);
+                    idx += sprintf(&out_buf[idx],"%f,",
+                                   q16_to_float(next_sample->data[i]));
                 }
             }
             out_buf[idx-1] = '\n';
             out_buf[idx] = 0;
         } else {
             /* send at least one channel */
-            idx += sprintf(&out_buf[idx],"%f,",next_sample->data[0]);
+            idx += sprintf(&out_buf[idx],"%f,",
+                           q16_to_float(next_sample->data[0]));
             out_buf[idx-1] = '\n';
             out_buf[idx] = 0;
         }
@@ -107,28 +112,57 @@ void esp_foc_scope_initalize(void)
     }
 }
 
+/* Snapshot every wired channel into the active write buffer. Returns
+ * true when the buffer just rolled over (caller is responsible for
+ * waking the daemon — the two public push variants below handle the
+ * wake with the appropriate FreeRTOS API for their context). */
+static inline bool scope_capture_frame(void)
+{
+    struct scope_frame *next_sample =
+        &scope_buffer[!ping_pong_switch][wr_buff_index];
+    for(int i = 0; i < CONFIG_ESP_FOC_SCOPE_NUM_CHANNELS; i++) {
+        if(used_channels & (1 << i)) {
+            next_sample->data[i] = *scope_channels[i];
+        } else {
+            next_sample->data[i] = 0;
+        }
+    }
+    wr_buff_index++;
+    if(wr_buff_index >= CONFIG_ESP_FOC_SCOPE_BUFFER_SIZE) {
+        rd_buff_index = 0;
+        wr_buff_index = 0;
+        ping_pong_switch ^= 1;
+        return true;
+    }
+    return false;
+}
+
 void esp_foc_scope_data_push(void)
 {
     if(!scope_enable) {
         ESP_LOGW(TAG, "ESP FOC scope is not ready yet, skipping...");
         return;
     }
-
-    struct scope_frame *next_sample = &scope_buffer[!ping_pong_switch][wr_buff_index];
-    for(int i = 0; i < CONFIG_ESP_FOC_SCOPE_NUM_CHANNELS; i++) {
-        if(used_channels & (1 << i)) {
-            next_sample->data[i] = q16_to_float(*scope_channels[i]);
-        } else {
-            next_sample->data[i] = 0.0f;
-        }
-    }
-
-    wr_buff_index++;
-    if(wr_buff_index >= CONFIG_ESP_FOC_SCOPE_BUFFER_SIZE) {
-        rd_buff_index = 0;
-        wr_buff_index = 0;
-        ping_pong_switch ^= 1;
+    if(scope_capture_frame()) {
         esp_foc_send_notification(scope_ev);
+    }
+}
+
+void esp_foc_scope_data_push_from_isr(void)
+{
+    /* ISR-context push for callers that live in IRAM (e.g. the FOC
+     * hot path inside the PWM ISR). Same buffer protocol as the
+     * task-context push, but the wake uses the FromISR notification
+     * variant so we never call xTaskNotifyGive from interrupt land.
+     *
+     * No ESP_LOGW guard here on purpose — printing inside an ISR
+     * would be way worse than silently dropping the rare case where
+     * push fires before scope_initalize(). */
+    if(!scope_enable) {
+        return;
+    }
+    if(scope_capture_frame()) {
+        esp_foc_send_notification_from_isr(scope_ev);
     }
 }
 

--- a/source/motor_control/esp_foc_tuner.c
+++ b/source/motor_control/esp_foc_tuner.c
@@ -150,6 +150,7 @@ static esp_foc_err_t handle_read(esp_foc_axis_t *axis,
     case ESP_FOC_TUNER_PARAM_INT_LIM_Q16:     value = lim; break;
     case ESP_FOC_TUNER_PARAM_V_MAX_Q16:       value = axis->max_voltage; break;
     case ESP_FOC_TUNER_PARAM_I_FILTER_FC_Q16: value = axis->current_filter_fc_hz_q16; break;
+    case ESP_FOC_TUNER_PARAM_LOOP_FS_HZ_Q16:  value = axis->current_filter_fs_hz_q16; break;
     default:
         return ESP_FOC_ERR_INVALID_ARG;
     }

--- a/test/mock_drivers.c
+++ b/test/mock_drivers.c
@@ -188,6 +188,16 @@ static void mock_isensor_set_filter_cutoff(esp_foc_isensor_t *self, float fc, fl
     m->last_filter_fs = fs;
 }
 
+static void mock_isensor_set_publish_targets(esp_foc_isensor_t *self,
+                                             q16_t *i_alpha_target,
+                                             q16_t *i_beta_target)
+{
+    mock_isensor_t *m = MOCK_ISENSOR_FROM_SELF(self);
+    m->set_publish_targets_count++;
+    m->publish_alpha_target = i_alpha_target;
+    m->publish_beta_target  = i_beta_target;
+}
+
 static void mock_isensor_set_callback(esp_foc_isensor_t *self, isensor_callback_t cb, void *param)
 {
     mock_isensor_t *m = MOCK_ISENSOR_FROM_SELF(self);
@@ -204,6 +214,7 @@ void mock_isensor_init(mock_isensor_t *m)
     m->interface.calibrate_isensors = mock_isensor_calibrate;
     m->interface.set_isensor_callback = mock_isensor_set_callback;
     m->interface.set_filter_cutoff = mock_isensor_set_filter_cutoff;
+    m->interface.set_publish_targets = mock_isensor_set_publish_targets;
 }
 
 esp_foc_isensor_t *mock_isensor_interface(mock_isensor_t *m)

--- a/test/mock_drivers.h
+++ b/test/mock_drivers.h
@@ -65,6 +65,9 @@ typedef struct {
     int set_filter_cutoff_count;
     float last_filter_fc;
     float last_filter_fs;
+    int set_publish_targets_count;
+    q16_t *publish_alpha_target;
+    q16_t *publish_beta_target;
     isensor_callback_t saved_callback;
     void *saved_callback_param;
 } mock_isensor_t;

--- a/test/test_angle_predictor.c
+++ b/test/test_angle_predictor.c
@@ -1,0 +1,228 @@
+/*
+ * MIT License
+ *
+ * Tests for the alpha-beta electrical-angle tracker. Strategy:
+ *   - synthesise a ground-truth angle that walks at a known electrical
+ *     frequency, sample it at the "encoder" rate (2 kHz), call
+ *     update() with the noisy / quantised samples and check that the
+ *     intermediate predict() values stay close to ground truth.
+ *   - exercise wrap-around, step-frequency convergence, and the
+ *     "encoder hung" degradation path.
+ *
+ * Tolerances are picked to stay above Q16 quantisation (one LSB at
+ * the integrator outputs) while still catching real algorithmic
+ * regressions.
+ */
+
+#include <math.h>
+#include <stdint.h>
+#include <unity.h>
+#include "espFoC/utils/angle_predictor_q16.h"
+#include "espFoC/utils/esp_foc_q16.h"
+
+static const float TWO_PI = 6.283185307179586f;
+
+static q16_t wrap_2pi_float(float a)
+{
+    while (a < 0.0f) {
+        a += TWO_PI;
+    }
+    while (a >= TWO_PI) {
+        a -= TWO_PI;
+    }
+    return q16_from_float(a);
+}
+
+static float angle_diff_rad(q16_t a_q16, float b)
+{
+    float a = q16_to_float(a_q16);
+    float d = a - b;
+    while (d > 3.14159265f) {
+        d -= TWO_PI;
+    }
+    while (d <= -3.14159265f) {
+        d += TWO_PI;
+    }
+    return d;
+}
+
+TEST_CASE("predictor: untouched returns 0",
+          "[espFoC][angle_predictor]")
+{
+    esp_foc_angle_predictor_q16_t p;
+    esp_foc_angle_predictor_init_q16(&p, 0.3f, 0.05f, 0u);
+    /* Before the first update, predict() returns 0 — sentinel value
+     * so the consumer never feeds a stale extrapolation into the PI. */
+    TEST_ASSERT_EQUAL_INT32(0, esp_foc_angle_predictor_predict_q16(&p, 1000u));
+}
+
+TEST_CASE("predictor: first update seeds without spurious omega",
+          "[espFoC][angle_predictor]")
+{
+    esp_foc_angle_predictor_q16_t p;
+    esp_foc_angle_predictor_init_q16(&p, 0.3f, 0.05f, 0u);
+
+    q16_t seed = q16_from_float(1.5f);
+    esp_foc_angle_predictor_update_q16(&p, seed, 1000u);
+    /* Right after the seeding update, predict() at the same instant
+     * must equal the seed and omega must still be zero. */
+    TEST_ASSERT_INT32_WITHIN(50, seed,
+                             esp_foc_angle_predictor_predict_q16(&p, 1000u));
+    TEST_ASSERT_EQUAL_INT32(0, esp_foc_angle_predictor_speed_q16(&p));
+}
+
+TEST_CASE("predictor: tracks a steady 60 Hz electrical rotation",
+          "[espFoC][angle_predictor]")
+{
+    /* 60 Hz electrical -> omega = 376.99 rad/s. Sample at 2 kHz
+     * (encoder cap). Predict at 40 kHz between samples. After ~40 ms
+     * of settling, the predicted angle must be within 0.05 rad
+     * (~3 degrees) of ground truth. */
+    esp_foc_angle_predictor_q16_t p;
+    const float fe_hz = 60.0f;
+    const float omega_true = TWO_PI * fe_hz;
+    const uint64_t enc_dt_us = 500u;       /* 2 kHz */
+    const uint64_t pred_dt_us = 25u;        /* 40 kHz */
+    const uint64_t total_us = 200000u;      /* 200 ms */
+
+    esp_foc_angle_predictor_init_q16(&p, 0.3f, 0.05f, 0u);
+
+    uint64_t t_us = 0u;
+    uint64_t next_enc = 0u;
+    float worst_err_late = 0.0f;
+    while (t_us <= total_us) {
+        if (t_us >= next_enc) {
+            float th = (omega_true * (float)t_us * 1e-6f);
+            esp_foc_angle_predictor_update_q16(&p, wrap_2pi_float(th), t_us);
+            next_enc += enc_dt_us;
+        }
+        if (t_us > 50000u) { /* skip the first 50 ms of settling */
+            float th_true = omega_true * (float)t_us * 1e-6f;
+            float err = fabsf(angle_diff_rad(
+                esp_foc_angle_predictor_predict_q16(&p, t_us), th_true));
+            if (err > worst_err_late) {
+                worst_err_late = err;
+            }
+        }
+        t_us += pred_dt_us;
+    }
+    TEST_ASSERT_TRUE_MESSAGE(worst_err_late < 0.05f,
+        "predictor lagged truth by more than 0.05 rad in steady state");
+    /* And the omega estimate should be close to the truth. */
+    float omega_est = q16_to_float(esp_foc_angle_predictor_speed_q16(&p));
+    TEST_ASSERT_FLOAT_WITHIN(omega_true * 0.02f, omega_true, omega_est);
+}
+
+TEST_CASE("predictor: converges on a step frequency change",
+          "[espFoC][angle_predictor]")
+{
+    /* Run at 60 Hz for 100 ms, then jump to 120 Hz. The tracker
+     * should re-acquire the new omega within ~30 ms of update calls
+     * (60 update cycles at 2 kHz). */
+    esp_foc_angle_predictor_q16_t p;
+    const uint64_t enc_dt_us = 500u;
+    esp_foc_angle_predictor_init_q16(&p, 0.3f, 0.05f, 0u);
+
+    /* First leg: 60 Hz for 100 ms */
+    float omega1 = TWO_PI * 60.0f;
+    uint64_t t = 0u;
+    float th = 0.0f;
+    while (t <= 100000u) {
+        th += omega1 * (float)enc_dt_us * 1e-6f;
+        esp_foc_angle_predictor_update_q16(&p, wrap_2pi_float(th), t);
+        t += enc_dt_us;
+    }
+
+    /* Step to 120 Hz, run another 60 ms, sample omega at the end. */
+    float omega2 = TWO_PI * 120.0f;
+    while (t <= 160000u) {
+        th += omega2 * (float)enc_dt_us * 1e-6f;
+        esp_foc_angle_predictor_update_q16(&p, wrap_2pi_float(th), t);
+        t += enc_dt_us;
+    }
+    float omega_est = q16_to_float(esp_foc_angle_predictor_speed_q16(&p));
+    TEST_ASSERT_FLOAT_WITHIN(omega2 * 0.05f, omega2, omega_est);
+}
+
+TEST_CASE("predictor: wrap-around does not produce omega glitches",
+          "[espFoC][angle_predictor]")
+{
+    /* Drive the angle past 2*pi back into [0, 2*pi) at every update.
+     * The residual wrap to (-pi, +pi] must keep the omega estimate
+     * locked at the true 60 Hz rate even when theta_meas jumps from
+     * ~6.27 rad to ~0.01 rad between samples. */
+    esp_foc_angle_predictor_q16_t p;
+    const uint64_t enc_dt_us = 500u;
+    const float omega_true = TWO_PI * 60.0f;
+    esp_foc_angle_predictor_init_q16(&p, 0.3f, 0.05f, 0u);
+    uint64_t t = 0u;
+    /* Run for 500 ms => ~30 wrap events at 60 Hz. */
+    for (int i = 0; i <= 1000; ++i) {
+        float th_true = omega_true * (float)t * 1e-6f;
+        esp_foc_angle_predictor_update_q16(&p, wrap_2pi_float(th_true), t);
+        t += enc_dt_us;
+    }
+    float omega_est = q16_to_float(esp_foc_angle_predictor_speed_q16(&p));
+    TEST_ASSERT_FLOAT_WITHIN(omega_true * 0.02f, omega_true, omega_est);
+    /* And predict() in the middle of a wrap stays in [0, 2*pi). */
+    q16_t pred = esp_foc_angle_predictor_predict_q16(&p, t + 250u);
+    float pred_f = q16_to_float(pred);
+    TEST_ASSERT_TRUE(pred_f >= 0.0f && pred_f < TWO_PI + 0.01f);
+}
+
+TEST_CASE("predictor: degrades gracefully when encoder hangs",
+          "[espFoC][angle_predictor]")
+{
+    /* If the I2C bus glitches and the outer task stops calling
+     * update() for 50 ms while predict() keeps firing in the ISR, the
+     * extrapolated angle must not blow up. At 60 Hz the true angle
+     * advances by ~18.85 rad (3 full revolutions); modulo 2*pi the
+     * error stays bounded by the omega_est noise floor. */
+    esp_foc_angle_predictor_q16_t p;
+    const uint64_t enc_dt_us = 500u;
+    const float omega_true = TWO_PI * 60.0f;
+    esp_foc_angle_predictor_init_q16(&p, 0.3f, 0.05f, 0u);
+    /* Settle the tracker for 100 ms. */
+    uint64_t t = 0u;
+    while (t <= 100000u) {
+        esp_foc_angle_predictor_update_q16(
+            &p, wrap_2pi_float(omega_true * (float)t * 1e-6f), t);
+        t += enc_dt_us;
+    }
+
+    /* Then go silent for 50 ms but keep predicting at 40 kHz. */
+    uint64_t silence_start = t;
+    float worst = 0.0f;
+    for (uint64_t dt = 25u; dt <= 50000u; dt += 25u) {
+        uint64_t t_now = silence_start + dt;
+        float th_true = omega_true * (float)t_now * 1e-6f;
+        float err = fabsf(angle_diff_rad(
+            esp_foc_angle_predictor_predict_q16(&p, t_now), th_true));
+        if (err > worst) {
+            worst = err;
+        }
+    }
+    /* With a perfect omega_est, drift would be zero; allow 0.5 rad
+     * worst-case to cover Q16 quantisation propagating over 50 ms. */
+    TEST_ASSERT_TRUE_MESSAGE(worst < 0.5f,
+        "predictor drifted more than 0.5 rad with no updates for 50 ms");
+}
+
+TEST_CASE("predictor: set_gains updates without losing state",
+          "[espFoC][angle_predictor]")
+{
+    esp_foc_angle_predictor_q16_t p;
+    esp_foc_angle_predictor_init_q16(&p, 0.3f, 0.05f, 0u);
+    esp_foc_angle_predictor_update_q16(&p, q16_from_float(1.0f), 1000u);
+    q16_t omega_before = p.omega_est;
+    q16_t theta_before = p.theta_est;
+    esp_foc_angle_predictor_set_gains_q16(&p, 0.5f, 0.10f);
+    TEST_ASSERT_EQUAL_INT32(omega_before, p.omega_est);
+    TEST_ASSERT_EQUAL_INT32(theta_before, p.theta_est);
+    /* New gains take effect immediately: alpha=1.0 makes the next
+     * update snap theta_est exactly to the measurement. */
+    esp_foc_angle_predictor_set_gains_q16(&p, 1.0f, 0.0f);
+    q16_t target = q16_from_float(2.5f);
+    esp_foc_angle_predictor_update_q16(&p, target, 2000u);
+    TEST_ASSERT_INT32_WITHIN(200, target, p.theta_est);
+}

--- a/test/test_axis_iq31_api.c
+++ b/test/test_axis_iq31_api.c
@@ -87,8 +87,16 @@ TEST_CASE("axis api: align and run happy path", "[espFoC][axis]")
     }
     vTaskDelay(pdMS_TO_TICKS(100));
     TEST_ASSERT_TRUE(mock_inv.set_voltages_count > 1);
+#if defined(CONFIG_ESP_FOC_ISR_HOT_PATH)
+    /* ISR hot path reads i_alpha / i_beta straight from the axis
+     * fields the ADC driver publishes; the loop does not call
+     * fetch_isensors() any more. The encoder still gets read in the
+     * outer task. */
+    TEST_ASSERT_TRUE(mock_rotor.read_counts_count > 0);
+#else
     TEST_ASSERT_TRUE(mock_isensor.fetch_count > 0);
     TEST_ASSERT_TRUE(mock_rotor.read_counts_count > 0);
+#endif
 }
 
 static int iq31_reg_cb_called;

--- a/test/test_axis_retune.c
+++ b/test/test_axis_retune.c
@@ -76,9 +76,15 @@ TEST_CASE("axis_tuning: retune output matches direct MPZ design",
     TEST_ASSERT_EQUAL(ESP_FOC_OK,
         esp_foc_axis_retune_current_pi_q16(&s_axis, r, l, bw));
 
-    /* Recompute via the design helper using the same loop_ts_us derivation. */
-    uint32_t loop_ts_us = (uint32_t)((1000000ULL * (uint64_t)ESP_FOC_LOW_SPEED_DOWNSAMPLING)
-                                     / 20000ULL);
+    /* Recompute via the design helper. retune now reads the loop dt
+     * straight from the axis PID so the test mirrors that exact
+     * derivation — under ISR_HOT_PATH the effective decimation is 1
+     * so deriving it from the static DOWNSAMPLING constant would
+     * disagree with what the axis actually carries. */
+    q16_t loop_dt_q16 = s_axis.torque_controller[0].dt;
+    uint32_t loop_ts_us = (uint32_t)(((int64_t)loop_dt_q16 * 1000000LL
+                                      + (int64_t)Q16_ONE / 2)
+                                     / (int64_t)Q16_ONE);
     esp_foc_pi_design_input_t in = {
         .motor_r_ohm = r,
         .motor_l_h   = l,

--- a/test/test_tuner.c
+++ b/test/test_tuner.c
@@ -258,6 +258,24 @@ TEST_CASE("tuner: motion target writes refused while override is OFF",
             payload, sizeof(payload), NULL, &resp_len));
 }
 
+TEST_CASE("tuner: read LOOP_FS_HZ returns the value init programmed",
+          "[espFoC][tuner]")
+{
+    setup_attached_axis();
+    /* esp_foc_initialize_axis stores the loop sample rate (PWM rate
+     * under ISR_HOT_PATH or pwm_rate / decimation under the legacy
+     * task path) on the axis. Tuner just reads it back. */
+    uint8_t resp[4] = {0};
+    size_t rl = sizeof(resp);
+    TEST_ASSERT_EQUAL(ESP_FOC_OK, esp_foc_tuner_handle_request(
+        0, ESP_FOC_TUNER_OP_READ, ESP_FOC_TUNER_PARAM_LOOP_FS_HZ_Q16,
+        NULL, 0, resp, &rl));
+    TEST_ASSERT_EQUAL(4, rl);
+    q16_t fs = deserialize_q16_le(resp);
+    TEST_ASSERT_EQUAL_INT32(s_axis.current_filter_fs_hz_q16, fs);
+    TEST_ASSERT_TRUE(fs > 0);
+}
+
 TEST_CASE("tuner: read I_FILTER_FC returns the value init programmed",
           "[espFoC][tuner]")
 {

--- a/tools/espfoc_studio/gui/analysis_panel.py
+++ b/tools/espfoc_studio/gui/analysis_panel.py
@@ -141,8 +141,20 @@ class AnalysisPanel(QWidget):
         except Exception:
             pass
 
+    def set_loop_rate_hz(self, fs_hz: float) -> None:
+        """Override the assumed loop sample rate. Called by the
+        MainWindow after reading PARAM_LOOP_FS_HZ from the firmware
+        on connect, so the discrete plant the analysis tab simulates
+        (step response, Bode, root locus) matches the rate the actual
+        current PI is firing at — Plan #2's ISR hot path runs at
+        40 kHz, the legacy task path runs at ~2 kHz, the predicted
+        response is wildly different between the two."""
+        if fs_hz > 1.0:
+            self._loop_fs_hz = fs_hz
+
     def _ts_s(self) -> float:
-        """The GUI assumes the default loop period (1 ms). Real-firmware
-        mode will override this once the axis state query grows a Ts
-        field; for now we use the same value the demo firmware uses."""
-        return 0.001
+        """Sample period the analysis math discretises against. Set
+        from the firmware via set_loop_rate_hz() at connect; falls
+        back to 1 ms if the firmware never reported one."""
+        fs = getattr(self, "_loop_fs_hz", None) or 1000.0
+        return 1.0 / fs

--- a/tools/espfoc_studio/gui/demo_firmware.py
+++ b/tools/espfoc_studio/gui/demo_firmware.py
@@ -257,6 +257,13 @@ class DemoFirmware(threading.Thread):
             self._send_response(seq, OK, struct.pack("<b", 0))
         elif pid == int(ParamId.I_FILTER_FC):
             self._send_response(seq, OK, _q16_to_bytes(self.current_filter_fc))
+        elif pid == int(ParamId.LOOP_FS_HZ):
+            # Demo firmware runs the synthetic plant + PID at ts_s, so
+            # the "loop rate" exposed to the host matches that. Real
+            # firmware reports either the PWM rate (ISR_HOT_PATH=y) or
+            # pwm_rate / decimation (legacy).
+            self._send_response(seq, OK,
+                                _q16_to_bytes(1.0 / max(self.motor.ts_s, 1e-9)))
         elif pid == int(ParamId.NVS_PRESENT):
             self._send_response(seq, OK,
                                 bytes([1 if self.nvs_overlay else 0]))

--- a/tools/espfoc_studio/gui/demo_firmware.py
+++ b/tools/espfoc_studio/gui/demo_firmware.py
@@ -57,8 +57,15 @@ class DemoFirmware(threading.Thread):
         self._dec = Decoder()
         self._state_lock = threading.Lock()
 
+        # ts_s mirrors the ISR_HOT_PATH default loop period (40 kHz
+         # PWM = 25 us). The demo runs SUB_STEPS=40 sub-iterations of
+         # the synthetic plant per wall-clock millisecond so the scope
+         # frame rate stays where the GUI expects it (~250 Hz, one
+         # frame per 4 ms wallclock = SUB_STEPS * SCOPE_DECIMATION).
+         # This keeps mpz_design(BW=4 kHz, fs=40 kHz) inside Nyquist
+         # and matches what the host's analysis tab discretises against.
         self.motor = motor or MotorParams(r_ohm=1.08, l_h=0.0018,
-                                          ts_s=0.001, v_max=12.0)
+                                          ts_s=25e-6, v_max=12.0)
         initial_gains = mpz_design(self.motor, bandwidth_hz=150.0)
         self.kp = initial_gains.kp
         self.ki = initial_gains.ki
@@ -99,7 +106,13 @@ class DemoFirmware(threading.Thread):
     # Configurable set of channels the demo streams on the SCOPE channel.
     # The firmware's esp_foc_scope.c emits CSV text as the payload; we do
     # the same here so the host-side ScopePanel can share the parser.
-    SCOPE_DECIMATION = 4  # one scope frame every N control steps (Ts = 1 ms)
+    # Sub-iterations of the synthetic plant per wall-clock tick. With
+    # ts_s = 25 us this gives a wall-clock budget of 1 ms per outer
+    # loop iteration, matching the previous demo cadence so the scope
+    # frame rate (one frame every SCOPE_DECIMATION outer iterations =
+    # 4 ms = 250 Hz) stays where the rest of the GUI expects it.
+    SUB_STEPS = 40
+    SCOPE_DECIMATION = 4
 
     def _scope_frame_csv(self) -> bytes:
         """Reproduce the firmware's esp_foc_scope.c payload format:
@@ -166,29 +179,39 @@ class DemoFirmware(threading.Thread):
     # --- Simulation loop ---------------------------------------------------
 
     def _simulate(self) -> None:
-        """Run the plant + PID at Ts. Matches the firmware closed-loop
-        enough for the scope to show sensible waveforms, and pushes a
-        SCOPE-channel frame every SCOPE_DECIMATION steps so the host
-        gets a live stream just like it would from a real bridge."""
+        """Run the plant + PID at Ts (matches the firmware ISR_HOT_PATH
+        loop rate of 40 kHz). Each wall-clock tick advances SUB_STEPS
+        sub-iterations of the closed loop in tight Python so a host
+        request like mpz_design(BW=4 kHz) lands on a plant that was
+        actually discretised at the same rate the design was computed
+        for. Scope frames are emitted every SUB_STEPS * SCOPE_DECIMATION
+        sub-steps (= one frame per 4 ms wallclock) so the GUI's frame
+        rate stays where it has been since the SVM panel was wired."""
         import math
         alpha = math.exp(-self.motor.r_ohm * self.motor.ts_s / self.motor.l_h)
-        counter = 0
+        sub_counter = 0
         seq = 0
+        # Wall-clock budget per outer iteration = SUB_STEPS * ts_s, e.g.
+        # 40 * 25 us = 1 ms — same cadence the demo had before the
+        # ts_s rebase to 40 kHz.
+        wall_dt = self.SUB_STEPS * self.motor.ts_s
         while not self._stop.is_set():
             with self._state_lock:
-                ref = self.target_iq if self.override else 0.0
-                err = ref - self._i_actual
-                u = self.kp * err + self._integ_prev
-                u = max(-self.motor.v_max, min(self.motor.v_max, u))
-                self._integ_prev = self._integ
-                self._integ += self.ki * err * self.motor.ts_s
-                if self.lim > 0:
-                    self._integ = max(-self.lim, min(self.lim, self._integ))
-                self._i_actual = (alpha * self._i_actual
-                                  + (1.0 - alpha) / self.motor.r_ohm * u)
-            counter += 1
-            if counter >= self.SCOPE_DECIMATION:
-                counter = 0
+                for _ in range(self.SUB_STEPS):
+                    ref = self.target_iq if self.override else 0.0
+                    err = ref - self._i_actual
+                    u = self.kp * err + self._integ_prev
+                    u = max(-self.motor.v_max, min(self.motor.v_max, u))
+                    self._integ_prev = self._integ
+                    self._integ += self.ki * err * self.motor.ts_s
+                    if self.lim > 0:
+                        self._integ = max(-self.lim,
+                                          min(self.lim, self._integ))
+                    self._i_actual = (alpha * self._i_actual
+                                      + (1.0 - alpha) / self.motor.r_ohm * u)
+            sub_counter += 1
+            if sub_counter >= self.SCOPE_DECIMATION:
+                sub_counter = 0
                 payload = self._scope_frame_csv()
                 if len(payload) <= MAX_PAYLOAD:
                     try:
@@ -197,7 +220,7 @@ class DemoFirmware(threading.Thread):
                     except Exception:
                         pass
                     seq = (seq + 1) & 0xFF
-            time.sleep(self.motor.ts_s)
+            time.sleep(wall_dt)
 
     # --- Dispatcher --------------------------------------------------------
 

--- a/tools/espfoc_studio/gui/main_window.py
+++ b/tools/espfoc_studio/gui/main_window.py
@@ -95,6 +95,19 @@ class MainWindow(QMainWindow):
         self._timer.timeout.connect(self._poll)
         self._timer.start()
 
+        # Pull the actual loop sample rate from the firmware so the
+        # Analysis tab discretises against the right Ts. Plan #2 (FOC
+        # in PWM ISR) bumps this from ~2 kHz to 40 kHz; without it
+        # the predicted step response on the Analysis tab would be
+        # off by the same 20x factor.
+        try:
+            fs_hz = client.read_loop_fs_hz()
+            if fs_hz > 1.0:
+                self._analysis.set_loop_rate_hz(fs_hz)
+                self._tuning.set_loop_rate_hz(fs_hz)
+        except TunerError:
+            pass
+
         # Prime the analysis view with the initial spinbox values.
         self._tuning._notify_params_changed()
 

--- a/tools/espfoc_studio/gui/tuning_panel.py
+++ b/tools/espfoc_studio/gui/tuning_panel.py
@@ -83,11 +83,14 @@ class TuningPanel(QWidget):
             lbl.setStyleSheet("font-family: monospace;")
         self._fc_label = QLabel("-")
         self._fc_label.setStyleSheet("font-family: monospace;")
+        self._loop_fs_label = QLabel("-")
+        self._loop_fs_label.setStyleSheet("font-family: monospace;")
         live_form.addRow("Kp [V/A]", self._kp_label)
         live_form.addRow("Ki [V/(A·s)]", self._ki_label)
         live_form.addRow("ILim [V]", self._lim_label)
         live_form.addRow("Vmax [V]", self._vmax_label)
         live_form.addRow("I-LPF fc [Hz]", self._fc_label)
+        live_form.addRow("Loop fs [Hz]", self._loop_fs_label)
         root.addWidget(live_box)
 
         # --- Manual gain editor ---
@@ -203,6 +206,15 @@ class TuningPanel(QWidget):
         root.addStretch(1)
 
     # --- Public slots (driven by MainWindow's timer) -----------------------
+
+    def set_loop_rate_hz(self, fs_hz: float) -> None:
+        """Receive the firmware's current PI sample rate (read once
+        on connect by MainWindow). Cached so poll() can show it
+        without a round-trip per refresh — the value is fixed for
+        the duration of a session."""
+        if fs_hz > 1.0:
+            self._loop_fs_hz = fs_hz
+            self._loop_fs_label.setText(f"{fs_hz:9.1f}")
 
     def poll(self) -> None:
         """Refresh the live readout. Called periodically by MainWindow."""

--- a/tools/espfoc_studio/protocol/tuner.py
+++ b/tools/espfoc_studio/protocol/tuner.py
@@ -39,6 +39,7 @@ class ParamId(IntEnum):
     INT_LIM_Q16     = 0x0012
     V_MAX_Q16       = 0x0013
     I_FILTER_FC     = 0x0014
+    LOOP_FS_HZ      = 0x0015
     AXIS_STATE      = 0x0040
     AXIS_LAST_ERR   = 0x0041
     NVS_PRESENT     = 0x0042
@@ -248,6 +249,13 @@ class TunerClient:
     def read_current_filter_fc(self) -> float:
         """Cutoff (Hz) of the per-phase Butterworth in the isensor driver."""
         return self._read_q16(ParamId.I_FILTER_FC)
+
+    def read_loop_fs_hz(self) -> float:
+        """Sample rate (Hz) at which the current PI fires on the
+        firmware. Equals the PWM rate under ISR_HOT_PATH and
+        pwm_rate / decimation under the legacy task path. The host
+        uses this to discretise the analysis-tab plant correctly."""
+        return self._read_q16(ParamId.LOOP_FS_HZ)
 
     def write_current_filter_fc(self, fc_hz: float) -> None:
         """Re-design the per-phase biquad with the supplied cutoff (Hz).


### PR DESCRIPTION
## Summary

Plan #2 of the industrial-bandwidth roadmap: move the FOC current loop into the PWM ISR. Park / current PI / inverse Park / SVPWM / set_voltages now execute every PWM period (40 kHz default) instead of every 20 PWM periods (the legacy 2 kHz task-based loop). User regulation_callback rate is unchanged (still 2 kHz). The slow encoder is bridged with an alpha-beta angle tracker — the outer task feeds it with each fresh reading; the ISR queries `predict()` to get a fresh extrapolated electrical angle every cycle.

Net effect: ~20x more bandwidth headroom on the inner current loop without needing a faster ADC (still ~50 kHz hard cap on plain ESP32) or a faster encoder (AS5600 stays at 2 kHz I2C-bound).

Plan #3 (offload sin/cos to the other core via IPC) was investigated and ruled out — `esp_ipc_isr_call` callback is asm-only on Xtensa, no async completion notification (only busy-wait), and the LUT-based sin+cos already runs in the order of hundreds of cycles. Documented for the record so it does not get re-investigated without new information.

## Architecture

```
ADC ISR  -- biquad filter then offset+gain+Clarke --> atomic write to axis.latest_i_alpha/beta
PWM ISR  -- read latest_i_alpha/beta -- predictor.predict(now) -- Park
            --> current PI (or override / open-loop) -- inverse Park + SVPWM -- set_voltages
            -- scope_data_push_from_isr -- downsample-- ; if 0 notify outer
Outer    -- read encoder (I2C/SPI may block) -- predictor.update under critical section
            -- velocity biquad -- notify regulator task -- regulation_callback
```

Three new contracts:
- `esp_foc_isensor_t` interface gets `set_publish_targets(self, q16_t *alpha_sink, q16_t *beta_sink)`. NULL targets disable the publish path so existing isensor implementations keep working unchanged.
- `esp_foc_scope_data_push_from_isr()` — same wire format as the task-context push but FromISR-safe (notification + buffer storage flipped from `float` to `q16_t` so the float conversion happens in the daemon, not in the hot path).
- `esp_foc_angle_predictor_q16_t` — alpha-beta tracker, default `alpha = 0.30`, `beta = 0.05`, override via Kconfig.

## Commits (7, individually reviewable)

1. `feat(predictor)` — angle_predictor_q16 module + 7 golden tests (steady-state tracking, step-frequency convergence, wrap-around, encoder-hung degradation, etc.)
2. `refactor(scope)` — `esp_foc_scope_data_push_from_isr()` + buffer flips to Q16
3. `refactor(isensor)` — Clarke-publish targets on continuous + one-shot ADC drivers + interface method
4. `feat(axis)` — predictor + `latest_i_alpha/beta` fields, three Kconfig entries (ISR_HOT_PATH, predictor alpha + beta)
5. `feat(control)` — `foc_hot_isr` in IRAM + thinned outer task; legacy 2.x path preserved verbatim under #else
6. `feat(autotune)` — `CONFIG_ESP_FOC_AUTOGEN_DECIMATION` defaults to 1 under ISR_HOT_PATH; PID `loop_dt` follows
7. `docs` — TUNING.md ISR section (incl. Plan #3 ruling) + changelog entry

## Validation

- **Unit tests:** 209 / 209 pass on QEMU (was 202; +7 predictor cases). Note: QEMU runs the legacy path because the mock inverter does not actually fire the timer ISR; the foc_hot_isr code path was inspected for IRAM annotations and ISR-safe API usage but full hardware validation has to happen on real silicon.
- **Firmware builds:** `tuner_studio_target` builds clean for esp32, esp32s3, esp32p4. `axis_sensored` builds clean for esp32s3. CONFIG_ESP_FOC_AUTOGEN_DECIMATION=1 confirmed by sdkconfig inspection.

## Try the new hot path

```bash
cd examples/tuner_studio_target
idf.py set-target esp32s3
idf.py menuconfig    # CONFIG_ESP_FOC_ISR_HOT_PATH already y by default
idf.py build flash monitor
```

Then connect TunerStudio and try a current step. The bandwidth ceiling that used to sit around ~150 Hz should now sit closer to 1.5 kHz before the loop starts misbehaving — exact number depends on motor / wiring.

If something blows up on a sensorless setup or some specific motor, set `CONFIG_ESP_FOC_ISR_HOT_PATH=n` to fall back to the legacy 2.x path while we investigate.

## Test plan

- [ ] CI green on the build job (axis_sensored, tuner_demo, tuner_studio_target s3 + esp32 + esp32p4, test_drivers/*)
- [ ] CI green on the python_tests job
- [ ] CI green on the QEMU unit_tests job (209 / 209)
- [ ] Hardware smoke: bring-up a real motor, push current bandwidth past 150 Hz, observe stability
