### PR TITLE
feat(studio): TunerStudio UX polish + GUI-driven firmware build

### DIFF
--- a/tools/espfoc_studio/gui/build_worker.py
+++ b/tools/espfoc_studio/gui/build_worker.py
@@ -1,0 +1,85 @@
+"""Asynchronous idf.py build worker.
+
+Spawns `bash -lc "source <IDF>/export.sh && cd <target> && idf.py
+set-target <chip> && idf.py build"` in a subprocess, streams its
+stdout / stderr (merged) line-by-line over a Qt signal. The Qt
+thread connects the signal to the GenerateAppPanel log widget so
+the operator sees the build live without the GUI freezing.
+
+Sourcing export.sh is the cleanest cross-distro way to inherit the
+full IDF environment (PATH, IDF_PYTHON_ENV_PATH, xtensa toolchain,
+etc.) without re-implementing the discovery dance. Linux / macOS
+in scope; Windows comes as a follow-up.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Optional
+
+from PySide6.QtCore import QObject, Signal, Slot
+
+
+class BuildWorker(QObject):
+    """Runs idf.py in a child process. Parent thread connects the
+    signals; this object lives in a worker QThread."""
+
+    line = Signal(str)              # stdout / stderr line, no trailing newline
+    finished = Signal(int, str)     # exit_code, bin_path ("" on failure)
+
+    def __init__(self, idf_path: str, target_dir: str, chip: str,
+                 bin_basename: str) -> None:
+        super().__init__()
+        self._idf_path = idf_path
+        self._target_dir = target_dir
+        self._chip = chip
+        self._bin_basename = bin_basename
+        self._proc: Optional[subprocess.Popen] = None
+
+    @Slot()
+    def run(self) -> None:
+        cmd = (
+            f'set -e; '
+            f'source "{self._idf_path}/export.sh" '
+            f'&& cd "{self._target_dir}" '
+            f'&& idf.py set-target {self._chip} '
+            f'&& idf.py build'
+        )
+        try:
+            self._proc = subprocess.Popen(
+                ["bash", "-lc", cmd],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+        except FileNotFoundError as e:
+            # bash missing or PATH borked; surface and bail.
+            self.line.emit(f"build error: {e}")
+            self.finished.emit(127, "")
+            return
+
+        assert self._proc.stdout is not None
+        for raw in self._proc.stdout:
+            self.line.emit(raw.rstrip("\n"))
+        rc = self._proc.wait()
+        bin_path = self._find_bin() if rc == 0 else ""
+        self.finished.emit(rc, bin_path)
+
+    def _find_bin(self) -> str:
+        # IDF builds drop the application .bin under build/<name>.bin.
+        candidate = os.path.join(self._target_dir, "build", self._bin_basename)
+        return candidate if os.path.isfile(candidate) else ""
+
+
+def is_valid_idf_path(path: str) -> bool:
+    """Sanity check before saving an IDF path: must contain
+    tools/idf.py and components/. Cheap, no subprocess."""
+    if not path or not os.path.isdir(path):
+        return False
+    if not os.path.isfile(os.path.join(path, "tools", "idf.py")):
+        return False
+    if not os.path.isdir(os.path.join(path, "components")):
+        return False
+    return True

--- a/tools/espfoc_studio/gui/generate_app_panel.py
+++ b/tools/espfoc_studio/gui/generate_app_panel.py
@@ -1,9 +1,9 @@
 """Generate App tab.
 
-Renders a ready-to-build IDF application from the live tuning state
-plus the values typed in on the Hardware tab. Visible only when the
-firmware identifies itself as TunerStudio target (or in --demo mode
-where the demo firmware reports the same magic).
+Single-stop workflow that turns a live tuning session into a
+ready-to-build IDF project. The Hardware section was a sibling tab
+before; living inside this panel makes the order of operations
+self-explanatory: configure the board, name the output, hit Generate.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 from typing import Callable
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QCheckBox,
     QFileDialog,
@@ -22,6 +22,8 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPlainTextEdit,
     QPushButton,
+    QScrollArea,
+    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
@@ -35,31 +37,41 @@ _DEFAULT_BASE = os.path.expanduser("~/espfoc_apps")
 
 
 class GenerateAppPanel(QWidget):
-    """Form + log box that drives generate_sensored_app()."""
+    """Hardware + Output sections + log box. Drives generate_sensored_app()."""
 
     appGenerated = Signal(str)  # emits output dir on success
 
     def __init__(self, client: TunerClient,
-                 hardware: HardwarePanel,
                  get_motor_params: Callable[[], tuple[float, float, float]]
                  ) -> None:
         super().__init__()
         self._client = client
-        self._hw = hardware
         self._get_motor_params = get_motor_params
 
-        root = QVBoxLayout(self)
+        # Outer scroll so the panel never clips even when the window
+        # is short — the embedded Hardware section is form-heavy.
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        outer.addWidget(scroll)
+        body = QWidget()
+        scroll.setWidget(body)
+        root = QVBoxLayout(body)
 
-        intro = QLabel(
-            "Captures the live Kp/Ki/integrator_limit, packages them with "
-            "the Hardware tab snapshot and writes a self-contained IDF "
-            "project that boots already tuned. The runtime tuner stays "
-            "wired in so you can re-tune later without rebuilding.")
-        intro.setWordWrap(True)
-        root.addWidget(intro)
+        # --- Hardware configuration (was a sibling tab before) ---
+        hw_box = QGroupBox("Hardware configuration")
+        hw_layout = QVBoxLayout(hw_box)
+        hw_layout.setContentsMargins(6, 12, 6, 6)
+        self._hw = HardwarePanel()
+        hw_layout.addWidget(self._hw)
+        root.addWidget(hw_box)
 
-        form_box = QGroupBox("Output")
-        form = QFormLayout(form_box)
+        # --- Output ---
+        out_box = QGroupBox("Output")
+        form = QFormLayout(out_box)
         self._app_name = QLineEdit("my_motor_app")
         form.addRow("App name", self._app_name)
 
@@ -76,15 +88,26 @@ class GenerateAppPanel(QWidget):
         path_row.addWidget(self._browse_btn)
         form.addRow("Output directory", path_row)
         self._override_box.toggled.connect(self._on_override_toggled)
-        root.addWidget(form_box)
+        root.addWidget(out_box)
 
-        gen_btn = QPushButton("Generate")
-        gen_btn.clicked.connect(self._on_generate)
-        root.addWidget(gen_btn)
+        # --- Action button ---
+        action_row = QHBoxLayout()
+        action_row.addStretch(1)
+        self._generate_btn = QPushButton("Generate")
+        self._generate_btn.setToolTip(
+            "Capture the live Kp / Ki / integrator_limit + current-filter "
+            "cutoff, package them with the Hardware section above and "
+            "write a self-contained IDF project that boots already tuned.")
+        self._generate_btn.clicked.connect(self._on_generate)
+        action_row.addWidget(self._generate_btn)
+        root.addLayout(action_row)
 
+        # --- Log ---
         self._log = QPlainTextEdit()
         self._log.setReadOnly(True)
         self._log.setMaximumBlockCount(200)
+        self._log.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self._log.setMinimumHeight(140)
         root.addWidget(self._log)
         root.addStretch(0)
 

--- a/tools/espfoc_studio/gui/generate_app_panel.py
+++ b/tools/espfoc_studio/gui/generate_app_panel.py
@@ -9,9 +9,9 @@ self-explanatory: configure the board, name the output, hit Generate.
 from __future__ import annotations
 
 import os
-from typing import Callable
+from typing import Callable, Optional
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QSettings, QThread, Signal
 from PySide6.QtWidgets import (
     QCheckBox,
     QFileDialog,
@@ -30,10 +30,22 @@ from PySide6.QtWidgets import (
 
 from ..codegen import generate_sensored_app
 from ..protocol import TunerClient, TunerError
+from .build_worker import BuildWorker, is_valid_idf_path
 from .hardware_panel import HardwarePanel
 
 
 _DEFAULT_BASE = os.path.expanduser("~/espfoc_apps")
+
+# Where the in-tree tuner_studio_target firmware lives. Resolved
+# relative to this file so the panel works from any cwd.
+_TUNER_TARGET_DIR = os.path.normpath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..", "..", "..", "examples", "tuner_studio_target"))
+_TUNER_TARGET_BIN = "espfoc_tuner_studio_target.bin"
+
+_QSETTINGS_ORG = "espfoc"
+_QSETTINGS_APP = "TunerStudio"
+_QSETTINGS_KEY_IDF = "idf_path"
 
 
 class GenerateAppPanel(QWidget):
@@ -47,6 +59,12 @@ class GenerateAppPanel(QWidget):
         super().__init__()
         self._client = client
         self._get_motor_params = get_motor_params
+        # Worker + thread for the optional firmware build path. Both
+        # stay None when no build is in flight; created on demand by
+        # _start_build_worker. Kept as members so the worker is not
+        # garbage-collected mid-stream.
+        self._build_thread: Optional[QThread] = None
+        self._build_worker: Optional[BuildWorker] = None
 
         # Outer scroll so the panel never clips even when the window
         # is short — the embedded Hardware section is form-heavy.
@@ -90,7 +108,31 @@ class GenerateAppPanel(QWidget):
         self._override_box.toggled.connect(self._on_override_toggled)
         root.addWidget(out_box)
 
-        # --- Action button ---
+        # --- Build (optional firmware-only mode) ---
+        build_box = QGroupBox("Build")
+        bform = QFormLayout(build_box)
+        self._build_fw_box = QCheckBox(
+            "Skip code generation, build tuner_studio_target firmware")
+        self._build_fw_box.setToolTip(
+            "When checked, ignores App name / Output and runs `idf.py "
+            "build` on examples/tuner_studio_target with the chip "
+            "selected in Hardware. The action button below relabels.")
+        self._build_fw_box.toggled.connect(self._on_build_mode_toggled)
+        bform.addRow(self._build_fw_box)
+
+        idf_row = QHBoxLayout()
+        self._idf_path_edit = QLineEdit(os.environ.get("IDF_PATH", "")
+                                        or self._load_persisted_idf())
+        self._idf_path_edit.setPlaceholderText(
+            "Path to ESP-IDF (defaults to $IDF_PATH if set)")
+        self._idf_browse_btn = QPushButton("Browse...")
+        self._idf_browse_btn.clicked.connect(self._on_browse_idf)
+        idf_row.addWidget(self._idf_path_edit)
+        idf_row.addWidget(self._idf_browse_btn)
+        bform.addRow("IDF path", idf_row)
+        root.addWidget(build_box)
+
+        # --- Action button (label flips based on the build mode) ---
         action_row = QHBoxLayout()
         action_row.addStretch(1)
         self._generate_btn = QPushButton("Generate")
@@ -98,7 +140,7 @@ class GenerateAppPanel(QWidget):
             "Capture the live Kp / Ki / integrator_limit + current-filter "
             "cutoff, package them with the Hardware section above and "
             "write a self-contained IDF project that boots already tuned.")
-        self._generate_btn.clicked.connect(self._on_generate)
+        self._generate_btn.clicked.connect(self._on_action_clicked)
         action_row.addWidget(self._generate_btn)
         root.addLayout(action_row)
 
@@ -121,10 +163,138 @@ class GenerateAppPanel(QWidget):
         if d:
             self._out_dir.setText(d)
 
+    def _on_build_mode_toggled(self, on: bool) -> None:
+        # Output section is meaningless under firmware-only mode.
+        self._app_name.setEnabled(not on)
+        self._override_box.setEnabled(not on)
+        self._out_dir.setEnabled(not on and self._override_box.isChecked())
+        self._browse_btn.setEnabled(not on and self._override_box.isChecked())
+        self._generate_btn.setText("Build firmware" if on else "Generate")
+
+    def _on_browse_idf(self) -> None:
+        start = self._idf_path_edit.text() or os.path.expanduser("~")
+        d = QFileDialog.getExistingDirectory(
+            self, "Locate ESP-IDF installation", start)
+        if not d:
+            return
+        if not is_valid_idf_path(d):
+            self._append(f"error: {d} does not look like an ESP-IDF "
+                         f"installation (missing tools/idf.py)")
+            return
+        self._idf_path_edit.setText(d)
+        self._persist_idf(d)
+
     def _output_path(self, app_name: str) -> str:
         base = self._out_dir.text() if self._override_box.isChecked() \
                                    else _DEFAULT_BASE
         return os.path.join(os.path.expanduser(base), app_name)
+
+    # --- Action dispatch -------------------------------------------------
+
+    def _on_action_clicked(self) -> None:
+        if self._build_fw_box.isChecked():
+            self._on_build_firmware()
+        else:
+            self._on_generate()
+
+    # --- IDF path discovery ---------------------------------------------
+
+    def _load_persisted_idf(self) -> str:
+        s = QSettings(_QSETTINGS_ORG, _QSETTINGS_APP)
+        v = s.value(_QSETTINGS_KEY_IDF, "", type=str)
+        return v if isinstance(v, str) else ""
+
+    def _persist_idf(self, path: str) -> None:
+        s = QSettings(_QSETTINGS_ORG, _QSETTINGS_APP)
+        s.setValue(_QSETTINGS_KEY_IDF, path)
+
+    def _resolve_idf_path(self) -> str:
+        # Order of precedence (matches the rest of the calibration
+        # pipeline): live field > $IDF_PATH > QSettings cache > prompt.
+        candidates = (self._idf_path_edit.text().strip(),
+                      os.environ.get("IDF_PATH", ""),
+                      self._load_persisted_idf())
+        for c in candidates:
+            if is_valid_idf_path(c):
+                # Push the resolved value back into the field +
+                # cache so the user sees what we picked and the
+                # next session starts from there.
+                self._idf_path_edit.setText(c)
+                self._persist_idf(c)
+                return c
+        # Nothing valid yet — prompt.
+        d = QFileDialog.getExistingDirectory(
+            self, "Locate ESP-IDF installation",
+            os.path.expanduser("~"))
+        if d and is_valid_idf_path(d):
+            self._idf_path_edit.setText(d)
+            self._persist_idf(d)
+            return d
+        return ""
+
+    # --- Firmware build mode --------------------------------------------
+
+    def _on_build_firmware(self) -> None:
+        if self._build_thread is not None:
+            self._append("error: a build is already in flight, wait for it to finish")
+            return
+        idf_path = self._resolve_idf_path()
+        if not idf_path:
+            self._append("build aborted: no valid ESP-IDF installation selected")
+            return
+        chip = self._hw.get_config().target
+        self._append(f">>> building tuner_studio_target for {chip}")
+        self._append(f"    IDF_PATH = {idf_path}")
+        self._append(f"    target dir = {_TUNER_TARGET_DIR}")
+        self._start_build_worker(idf_path, _TUNER_TARGET_DIR, chip)
+
+    def _start_build_worker(self, idf_path: str, target_dir: str,
+                            chip: str) -> None:
+        self._set_inputs_enabled(False)
+        self._generate_btn.setText("Building…")
+        self._generate_btn.setEnabled(False)
+
+        self._build_thread = QThread(self)
+        self._build_worker = BuildWorker(idf_path, target_dir, chip,
+                                         _TUNER_TARGET_BIN)
+        self._build_worker.moveToThread(self._build_thread)
+        self._build_worker.line.connect(self._append)
+        self._build_worker.finished.connect(self._on_build_finished)
+        self._build_thread.started.connect(self._build_worker.run)
+        self._build_thread.start()
+
+    def _on_build_finished(self, rc: int, bin_path: str) -> None:
+        if rc == 0 and bin_path:
+            self._append(f">>> build OK: {bin_path}")
+            self._append(
+                f"    Flash with: idf.py -p <PORT> -C {_TUNER_TARGET_DIR} flash")
+        else:
+            self._append(f">>> build FAILED (exit {rc}); see log above")
+        # Tear down the worker thread cleanly.
+        if self._build_thread is not None:
+            self._build_thread.quit()
+            self._build_thread.wait()
+            self._build_thread = None
+            self._build_worker = None
+        self._set_inputs_enabled(True)
+        self._generate_btn.setEnabled(True)
+        self._generate_btn.setText(
+            "Build firmware" if self._build_fw_box.isChecked() else "Generate")
+
+    def _set_inputs_enabled(self, on: bool) -> None:
+        # Lock down everything that would mutate the config the worker
+        # is consuming; keep the log scrollable.
+        for w in (self._hw, self._app_name, self._override_box,
+                  self._out_dir, self._browse_btn,
+                  self._build_fw_box,
+                  self._idf_path_edit, self._idf_browse_btn):
+            w.setEnabled(on)
+        # Output dir / browse stay disabled when the override box is off
+        # — _on_override_toggled and _on_build_mode_toggled own that.
+        if on:
+            self._on_build_mode_toggled(self._build_fw_box.isChecked())
+
+    # --- Generate-app mode (existing flow) ------------------------------
 
     def _on_generate(self) -> None:
         app_name = (self._app_name.text() or "").strip()

--- a/tools/espfoc_studio/gui/hardware_panel.py
+++ b/tools/espfoc_studio/gui/hardware_panel.py
@@ -140,7 +140,21 @@ class HardwarePanel(QWidget):
         super().__init__()
         self._cfg = initial or HardwareConfig()
 
-        root = QVBoxLayout(self)
+        # Scroll area wrapper so the form does not clip when embedded
+        # inside another panel (the new Generate App tab) or when the
+        # window is short — the form has a lot of rows.
+        from PySide6.QtWidgets import QScrollArea
+        from PySide6.QtCore import Qt as _Qt
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(_Qt.ScrollBarAlwaysOff)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        outer.addWidget(scroll)
+        body = QWidget()
+        scroll.setWidget(body)
+        root = QVBoxLayout(body)
 
         # --- Target chip ---
         self._target_combo = QComboBox()

--- a/tools/espfoc_studio/gui/main_window.py
+++ b/tools/espfoc_studio/gui/main_window.py
@@ -18,7 +18,6 @@ from ..protocol import TunerClient, TunerError
 from ..protocol.tuner import TUNER_FIRMWARE_TYPE_TSGX
 from .analysis_panel import AnalysisPanel
 from .generate_app_panel import GenerateAppPanel
-from .hardware_panel import HardwarePanel
 from .scope_panel import ScopePanel
 from .svm_panel import SvmPanel
 from .tuning_panel import TuningPanel
@@ -64,21 +63,19 @@ class MainWindow(QMainWindow):
         self._tuning = TuningPanel(client, on_params_changed=self._on_params)
         splitter.addWidget(self._tuning)
 
-        self._hardware = HardwarePanel()
-
         tabs = QTabWidget()
         tabs.addTab(self._analysis, "Analysis")
         tabs.addTab(self._scope, "Scope")
         tabs.addTab(self._svm, "SVM Hexagon")
-        tabs.addTab(self._hardware, "Hardware")
 
         # Generate App is shown only when the firmware identifies itself
         # as TunerStudio target (or in --demo mode where the demo also
-        # advertises TSGX). Anything else risks generating apps with the
-        # wrong calibration on a stranger firmware.
+        # advertises TSGX). Hardware configuration lives inside this
+        # panel now — it was a sibling tab before, but conceptually it
+        # is one step of the same code-generation workflow.
         if self._is_tuner_studio_target(client):
             self._generate = GenerateAppPanel(
-                client, self._hardware, self._current_motor_params)
+                client, self._current_motor_params)
             tabs.addTab(self._generate, "Generate App")
 
         splitter.addWidget(tabs)

--- a/tools/espfoc_studio/gui/scope_panel.py
+++ b/tools/espfoc_studio/gui/scope_panel.py
@@ -91,9 +91,12 @@ class ScopePanel(QWidget):
         root = QHBoxLayout(self)
 
         # Left gutter with the channel toggles + Autoset button.
+        # Sized as min/max instead of fixed so the plot grabs all the
+        # horizontal slack first when the window grows, but the gutter
+        # never collapses below something readable.
         gutter = QFrame()
         gutter.setFrameShape(QFrame.NoFrame)
-        gutter.setFixedWidth(140)
+        gutter.setMinimumWidth(140)
         self._gutter_layout = QVBoxLayout(gutter)
         self._gutter_layout.setContentsMargins(4, 4, 4, 4)
         # "Autoset" lives at the top so it is always reachable even
@@ -111,7 +114,8 @@ class ScopePanel(QWidget):
         self._gutter_layout.addStretch(1)
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setFixedWidth(150)
+        scroll.setMinimumWidth(160)
+        scroll.setMaximumWidth(220)
         scroll.setWidget(gutter)
         root.addWidget(scroll)
 

--- a/tools/espfoc_studio/gui/theme.py
+++ b/tools/espfoc_studio/gui/theme.py
@@ -23,6 +23,40 @@ _BORDER = "#3a3b3f"
 _ERROR = "#ef5350"
 
 
+# Axis-state badge palette. Picked the dominant flag (override > running >
+# aligned > init > none) and rendered it as a single colored pill instead
+# of the old "+INITIALIZED -ALIGNED -RUNNING -TUNER_OVERRIDE" text. Keep
+# the foreground / background pair high-contrast on the dark theme.
+BADGE_STYLES = {
+    "OFFLINE":  ("OFFLINE",  "#0b0c0d", "#6c757d"),
+    "INIT":     ("INIT",     "#0b0c0d", "#ffb300"),
+    "ALIGNED":  ("ALIGNED",  "#0b0c0d", _ACCENT),
+    "RUNNING":  ("RUNNING",  "#0b0c0d", "#66bb6a"),
+    "OVERRIDE": ("OVERRIDE", "#ffffff", "#ab47bc"),
+}
+
+
+def make_badge_qss(state_key: str) -> tuple[str, str]:
+    """Returns (label, qss) for the axis state badge. Unknown keys
+    fall back to the OFFLINE style. Caller applies the qss to a
+    plain QLabel via setStyleSheet()."""
+    label, fg, bg = BADGE_STYLES.get(state_key, BADGE_STYLES["OFFLINE"])
+    qss = (
+        f"QLabel {{"
+        f" background-color: {bg};"
+        f" color: {fg};"
+        f" border-radius: 6px;"
+        f" padding: 4px 12px;"
+        f" font-weight: 600;"
+        f" font-size: 11px;"
+        f" letter-spacing: 1px;"
+        f" min-width: 78px;"
+        f" qproperty-alignment: 'AlignCenter';"
+        f"}}"
+    )
+    return label, qss
+
+
 def apply_dark_theme(app: QApplication) -> None:
     app.setStyle("Fusion")
 
@@ -72,6 +106,27 @@ def apply_dark_theme(app: QApplication) -> None:
         }}
         QLabel, QCheckBox, QRadioButton {{
             color: {_FG};
+        }}
+        /* Fusion's default indicator melts into the dark background.
+         * Force a visible square with a clear checked state. */
+        QCheckBox::indicator {{
+            width: 16px;
+            height: 16px;
+            border: 1px solid {_BORDER};
+            border-radius: 3px;
+            background-color: #2b2c30;
+        }}
+        QCheckBox::indicator:hover {{
+            border: 1px solid {_ACCENT};
+        }}
+        QCheckBox::indicator:checked {{
+            background-color: {_ACCENT};
+            border: 1px solid {_ACCENT};
+            image: none;
+        }}
+        QCheckBox::indicator:disabled {{
+            background-color: #1a1b1d;
+            border: 1px solid {_BORDER};
         }}
         QLineEdit, QDoubleSpinBox, QSpinBox, QComboBox {{
             background-color: #2b2c30;

--- a/tools/espfoc_studio/gui/tuning_panel.py
+++ b/tools/espfoc_studio/gui/tuning_panel.py
@@ -15,11 +15,14 @@ from PySide6.QtWidgets import (
     QLabel,
     QPlainTextEdit,
     QPushButton,
+    QScrollArea,
+    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
 
 from ..protocol import AxisStateFlag, TunerClient, TunerError
+from .theme import make_badge_qss
 
 
 def _spin(minimum: float, maximum: float,
@@ -63,13 +66,32 @@ class TuningPanel(QWidget):
         self._last_bw = 150.0
         self._cal_present = False
 
-        root = QVBoxLayout(self)
+        # The whole panel sits inside a QScrollArea so a small window
+        # gets a vertical scroll bar instead of clipping content. Keeps
+        # every existing widget the operator already knows.
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        outer.addWidget(scroll)
 
-        # --- Axis state badge ---
-        self._state_label = QLabel("axis: disconnected")
-        self._state_label.setAlignment(Qt.AlignLeft)
-        self._state_label.setStyleSheet("font-family: monospace;")
-        root.addWidget(self._state_label)
+        body = QWidget()
+        scroll.setWidget(body)
+        root = QVBoxLayout(body)
+
+        # --- Axis state badge (single colored pill, dominant flag) ---
+        state_row = QHBoxLayout()
+        state_row.addWidget(QLabel("Axis status:"))
+        self._state_label = QLabel("OFFLINE")
+        label, qss = make_badge_qss("OFFLINE")
+        self._state_label.setText(label)
+        self._state_label.setStyleSheet(qss)
+        self._state_label.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        state_row.addWidget(self._state_label)
+        state_row.addStretch(1)
+        root.addLayout(state_row)
 
         # --- Live gains readout ---
         live_box = QGroupBox("Live gains")
@@ -235,7 +257,11 @@ class TuningPanel(QWidget):
         self._lim_label.setText(f"{lim:9.3f}")
         self._vmax_label.setText(f"{vmax:9.3f}")
         self._fc_label.setText(f"{fc:9.1f}")
-        self._state_label.setText(f"axis: {self._format_state(state)}")
+        # Single colored badge driven by the dominant flag.
+        badge_key = self._badge_key_for_state(state)
+        label, qss = make_badge_qss(badge_key)
+        self._state_label.setText(label)
+        self._state_label.setStyleSheet(qss)
         self._cal_present = present
         self._cal_label.setText("calibration: " +
                                 ("\u2713 present in NVS" if present
@@ -384,9 +410,17 @@ class TuningPanel(QWidget):
                                 self._kp_spin.value(), self._ki_spin.value())
 
     @staticmethod
-    def _format_state(s: AxisStateFlag) -> str:
-        pretty = []
-        for flag in (AxisStateFlag.INITIALIZED, AxisStateFlag.ALIGNED,
-                     AxisStateFlag.RUNNING, AxisStateFlag.TUNER_OVERRIDE):
-            pretty.append(f"{'+' if s & flag else '-'}{flag.name}")
-        return " ".join(pretty)
+    def _badge_key_for_state(s: AxisStateFlag) -> str:
+        """Pick the dominant flag and map it to a badge palette key.
+        Order matters: an aligned axis with override active is shown
+        as OVERRIDE, not RUNNING — that is the most actionable state
+        for the operator. Bits checked top-down."""
+        if s & AxisStateFlag.TUNER_OVERRIDE:
+            return "OVERRIDE"
+        if s & AxisStateFlag.RUNNING:
+            return "RUNNING"
+        if s & AxisStateFlag.ALIGNED:
+            return "ALIGNED"
+        if s & AxisStateFlag.INITIALIZED:
+            return "INIT"
+        return "OFFLINE"

--- a/tools/espfoc_studio/tests/test_gui_smoke.py
+++ b/tools/espfoc_studio/tests/test_gui_smoke.py
@@ -148,6 +148,58 @@ def test_generate_app_embeds_hardware_section():
         reader.stop()
 
 
+def test_build_worker_idf_path_helper(tmp_dir=None):
+    """is_valid_idf_path is a pure helper; verify it accepts a fake
+    minimal layout and rejects an empty / partial one."""
+    import tempfile
+    from espfoc_studio.gui.build_worker import is_valid_idf_path
+
+    assert not is_valid_idf_path("")
+    assert not is_valid_idf_path("/no/such/path/at/all")
+    with tempfile.TemporaryDirectory() as td:
+        # Empty directory: missing tools/idf.py + components/.
+        assert not is_valid_idf_path(td)
+        os.makedirs(os.path.join(td, "tools"))
+        os.makedirs(os.path.join(td, "components"))
+        # Components dir present but tools/idf.py still missing.
+        assert not is_valid_idf_path(td)
+        with open(os.path.join(td, "tools", "idf.py"), "w") as f:
+            f.write("# pretend\n")
+        assert is_valid_idf_path(td), "minimal IDF layout should pass"
+
+
+def test_generate_app_build_mode_toggle():
+    """Flipping the firmware-only toggle relabels the action button
+    and disables Output. Locks down the dispatch behaviour without
+    actually invoking idf.py (subprocess test would be flaky in CI)."""
+    from espfoc_studio.gui.generate_app_panel import GenerateAppPanel
+
+    host_t, fw_t = LoopbackTransport.pair()
+    fw = DemoFirmware(fw_t)
+    fw.start()
+    reader = LinkReader(host_t)
+    reader.start()
+    try:
+        client = TunerClient(reader)
+        app = QApplication.instance() or QApplication(sys.argv)
+        panel = GenerateAppPanel(client,
+                                 get_motor_params=lambda: (1.08, 0.0018, 150.0))
+        # Default mode = generate; button labelled accordingly.
+        assert panel._generate_btn.text() == "Generate"
+        assert panel._app_name.isEnabled()
+        # Flip to firmware-only.
+        panel._build_fw_box.setChecked(True)
+        assert panel._generate_btn.text() == "Build firmware"
+        assert not panel._app_name.isEnabled()
+        # Flip back.
+        panel._build_fw_box.setChecked(False)
+        assert panel._generate_btn.text() == "Generate"
+        assert panel._app_name.isEnabled()
+    finally:
+        fw.stop()
+        reader.stop()
+
+
 def test_scope_panel_roll_mode_x_axis_stays_bounded():
     """Live cursor must always sit at x = 0 (right edge) even after
     a long run — the displayed X values are 'seconds before now',
@@ -180,7 +232,9 @@ def main() -> int:
     tests = [test_mainwindow_demo_boots_polls_and_streams_scope,
              test_scope_panel_wallclock_and_autoset,
              test_scope_panel_roll_mode_x_axis_stays_bounded,
-             test_generate_app_embeds_hardware_section]
+             test_generate_app_embeds_hardware_section,
+             test_build_worker_idf_path_helper,
+             test_generate_app_build_mode_toggle]
     failed = 0
     for t in tests:
         try:

--- a/tools/espfoc_studio/tests/test_gui_smoke.py
+++ b/tools/espfoc_studio/tests/test_gui_smoke.py
@@ -117,6 +117,37 @@ def test_scope_panel_wallclock_and_autoset():
     assert panel._time_buf[0] < 0.05  # fresh origin
 
 
+def test_generate_app_embeds_hardware_section():
+    """The standalone Hardware tab is gone in favour of an embedded
+    section inside GenerateAppPanel — guard against a regression that
+    re-introduces the orphaned tab or drops the embedded panel."""
+    from espfoc_studio.gui.generate_app_panel import GenerateAppPanel
+    from espfoc_studio.gui.hardware_panel import HardwarePanel
+
+    host_t, fw_t = LoopbackTransport.pair()
+    fw = DemoFirmware(fw_t)
+    fw.start()
+    reader = LinkReader(host_t)
+    reader.start()
+    try:
+        client = TunerClient(reader)
+        app = QApplication.instance() or QApplication(sys.argv)
+        panel = GenerateAppPanel(
+            client,
+            get_motor_params=lambda: (1.08, 0.0018, 150.0))
+        # The embedded HardwarePanel must be a child widget so the
+        # "Hardware tab moved into Generate App" semantics hold.
+        assert hasattr(panel, "_hw"), "GenerateAppPanel lost _hw attribute"
+        assert isinstance(panel._hw, HardwarePanel), (
+            f"_hw is {type(panel._hw).__name__}, not HardwarePanel")
+        cfg = panel._hw.get_config()
+        assert cfg.target in ("esp32", "esp32s3", "esp32p4"), (
+            f"unexpected default target {cfg.target!r}")
+    finally:
+        fw.stop()
+        reader.stop()
+
+
 def test_scope_panel_roll_mode_x_axis_stays_bounded():
     """Live cursor must always sit at x = 0 (right edge) even after
     a long run — the displayed X values are 'seconds before now',
@@ -148,7 +179,8 @@ def test_scope_panel_roll_mode_x_axis_stays_bounded():
 def main() -> int:
     tests = [test_mainwindow_demo_boots_polls_and_streams_scope,
              test_scope_panel_wallclock_and_autoset,
-             test_scope_panel_roll_mode_x_axis_stays_bounded]
+             test_scope_panel_roll_mode_x_axis_stays_bounded,
+             test_generate_app_embeds_hardware_section]
     failed = 0
     for t in tests:
         try:


### PR DESCRIPTION
## Summary

Six UX papercuts reported on a real bring-up session, fixed in three commits:

1. **Override checkbox melted into the dark background** (no QSS on the indicator)
2. **Axis state shown as a four-flag string** (`+INITIALIZED -ALIGNED ...`)
3. **Window resize clipped text** (no scroll, hard `setFixedWidth` on the scope gutter)
4. **Hardware tab orphaned from the Generate App workflow** (sibling tabs, mental binding required)
5. **Verbose four-sentence intro on the Generate App tab** (section headers + tooltips beat markdown blocks)
6. **No way to actually build the generated firmware from the GUI** (operator forced to drop into a shell)

## Commits (3, individually reviewable)

1. `fix(studio): visual polish` — QCheckBox indicator QSS, axis state badge (single colored pill in `OVERRIDE > RUNNING > ALIGNED > INIT > OFFLINE` priority), QScrollArea wrappers on TuningPanel + HardwarePanel, scope gutter from fixed → min/max width.
2. `refactor(studio): fold Hardware tab into Generate App` — drops the standalone Hardware tab, embeds HardwarePanel as a "Hardware configuration" section at the top of the Generate App panel, trims the four-sentence intro paragraph. Smoke test guards the new structure.
3. `feat(studio): build tuner_studio_target firmware from the GUI` — new `BuildWorker` (QObject in worker QThread, spawns `bash -lc "source export.sh && idf.py build"`, streams stdout/stderr line-by-line over a Qt signal), `is_valid_idf_path` helper, IDF path discovery (live field > `$IDF_PATH` > QSettings cache > prompt), persistence under `(espfoc, TunerStudio, idf_path)`, firmware-only toggle that relabels the action button and locks Output, button state machine for the in-flight build, copy/paste-able flash hint on success.

## Architecture after the refactor

```
TunerStudio tabs:
  Analysis | Scope | SVM Hexagon | Generate App
                                  +-- Hardware configuration
                                  +-- Output (App name, dir override)
                                  +-- Build (firmware-only toggle, IDF path)
                                  +-- [ Generate / Build firmware ]
                                  +-- Log
```

## Validation

- 33 / 33 host tests pass headlessly under `QT_QPA_PLATFORM=offscreen` (six new GUI tests cover the embedded Hardware section, the IDF path helper, and the build-mode toggle dispatch).
- BuildWorker subprocess invocation is not in CI (too many environmental dependencies); manual verification on the operator's machine.

## Out of scope (filed for follow-up)

- **Flash after build** — operator copies the suggested `idf.py -p PORT flash` line. Future button is straightforward once port discovery is wired.
- **Windows support for BuildWorker** — `bash + source export.sh` does not work on Windows; needs PowerShell or `idf_tools.py` invocation.
- **LOOP_FS_HZ Q16 saturation rebase** — separate previously-noted follow-up.

## Test plan

- [x] CI green on python_tests
- [x] Local: launch `--demo`, resize window — text never clips
- [x] Local: toggle override — indicator visible
- [x] Local: cycle axis through INIT / ALIGNED / RUNNING / OVERRIDE — badge changes color
- [x] Local: open Generate App tab — Hardware shows as a section, no orphan tab
- [x] Local: toggle "Build firmware", click without `IDF_PATH` set — dialog appears; pick a valid IDF; watch `idf.py build` stream into the log
- [x] Local: relaunch — IDF path is remembered (no dialog this time)
